### PR TITLE
Remove deployment to old NS from circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,21 +272,6 @@ workflows:
           requires:
             - install_dependencies
       - deploy:
-          name: Deploy UAT to existing namespace
-          environment: uat
-          context: laa-estimate-eligibility-uat
-          requires:
-            - linters
-            - run_specs
-            - end2end_tests
-            - linters
-            - build_and_push
-          post-steps:
-            - jira/notify:
-                job_type: deployment
-                environment: UAT
-                environment_type: testing
-      - deploy:
           name: Deploy UAT to new namespace
           environment: ccq-uat
           context: laa-check-client-qualifies-uat
@@ -296,30 +281,11 @@ workflows:
             - end2end_tests
             - linters
             - build_and_push
-            - Deploy UAT to existing namespace
           post-steps:
             - jira/notify:
                 job_type: deployment
                 environment: UAT
                 environment_type: testing
-      - deploy:
-          name: Deploy staging to existing namespace
-          environment: staging
-          context: laa-estimate-eligibility-staging
-          requires:
-            - run_specs
-            - end2end_tests
-            - linters
-            - build_and_push
-          post-steps:
-            - jira/notify:
-                job_type: deployment
-                environment: Staging
-                environment_type: staging
-          filters:
-            branches:
-              only:
-                - main
       - deploy:
           name: Deploy staging to new namespace
           environment: ccq-staging
@@ -329,30 +295,11 @@ workflows:
             - end2end_tests
             - linters
             - build_and_push
-            - Deploy staging to existing namespace
           post-steps:
             - jira/notify:
                 job_type: deployment
                 environment: Staging
                 environment_type: staging
-          filters:
-            branches:
-              only:
-                - main
-      - deploy:
-          name: Deploy production to existing namespace
-          environment: production
-          context: laa-estimate-eligibility-production
-          requires:
-            - run_specs
-            - end2end_tests
-            - linters
-            - build_and_push
-          post-steps:
-            - jira/notify:
-                job_type: deployment
-                environment: Production
-                environment_type: production
           filters:
             branches:
               only:
@@ -366,7 +313,6 @@ workflows:
             - end2end_tests
             - linters
             - build_and_push
-            - Deploy production to existing namespace
           post-steps:
             - jira/notify:
                 job_type: deployment


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-XXX)

Now that we have switched to the new NS we can stop deploying to the old NS. This will save us on circle credits as we have been using more over the last few weeks as we have been dual deploying.

<!-- fill this in -->

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
