### PR TITLE
Remove attempt to interact with old UAT namespace

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -161,18 +161,6 @@ jobs:
         branch: ${{ fromJSON(needs.combine-prs.outputs.branches) }}
     steps:
       - uses: actions/checkout@v4
-      - name: Delete from old UAT namespace
-        id: delete_old_uat
-        uses: ./.github/actions/delete-uat-release
-        with:
-          k8s_cluster: ${{ secrets.K8S_GHA_UAT_CLUSTER_NAME }}
-          k8s_cluster_cert: ${{ secrets.K8S_GHA_UAT_CLUSTER_CERT }}
-          k8s_namespace: ${{ secrets.K8S_GHA_UAT_NAMESPACE }}
-          k8s_token: ${{ secrets.K8S_GHA_UAT_TOKEN }}
-          branch_name: ${{ matrix.branch }}
-      - name: Old result
-        shell: bash
-        run: echo ${{ steps.delete_old_uat.outputs.delete-message }}\
       - name: Delete from UAT namespace
         id: delete_uat
         uses: ./.github/actions/delete-uat-release

--- a/.github/workflows/delete_uat_release.yml
+++ b/.github/workflows/delete_uat_release.yml
@@ -10,17 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Delete from old UAT namespace
-        id: delete_old_uat
-        uses: ./.github/actions/delete-uat-release
-        with:
-          k8s_cluster: ${{ secrets.K8S_GHA_UAT_CLUSTER_NAME }}
-          k8s_cluster_cert: ${{ secrets.K8S_GHA_UAT_CLUSTER_CERT }}
-          k8s_namespace: ${{ secrets.K8S_GHA_UAT_NAMESPACE }}
-          k8s_token: ${{ secrets.K8S_GHA_UAT_TOKEN }}
-      - name: Old result
-        shell: bash
-        run: echo ${{ steps.delete_old_uat.outputs.delete-message }}\
       - name: Delete from UAT namespace
         id: delete_uat
         uses: ./.github/actions/delete-uat-release


### PR DESCRIPTION
## What changed and why

Our GitHub actions were trying to use secrets that no longer existed to delete releases from the now-removed old UAT namespace. This fixes that.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
