### PR TITLE
EL-1282: Mortgage not showing on CW forms

### DIFF
--- a/app/models/concerns/property_summarisable.rb
+++ b/app/models/concerns/property_summarisable.rb
@@ -98,7 +98,7 @@ module PropertySummarisable
   end
 
   def non_smod_additional_properties_mortgage
-    additional_properties_sum("outstaging_mortgage", smod: false)
+    additional_properties_sum("outstanding_mortgage", smod: false)
   end
 
   def smod_additional_properties_outstanding_mortgage

--- a/spec/models/controlled_work_document_content_spec.rb
+++ b/spec/models/controlled_work_document_content_spec.rb
@@ -356,6 +356,12 @@ RSpec.describe ControlledWorkDocumentContent do
           expect(described_class.new(session_data).additional_properties_mortgage).to eq 120_000
         end
       end
+
+      describe "#non_smod_additional_properties_mortgage" do
+        it "returns the correct figure" do
+          expect(described_class.new(session_data).non_smod_additional_properties_mortgage).to eq 120_000
+        end
+      end
     end
   end
 


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1282)

## What changed and why

A typo meant that when displaying the combined outstanding mortgage for all non-smod properties, we were always returning 0. This fixes that and adds a test.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
