### PR TITLE
EL-1278: Update to view and added in some check methods.

### DIFF
--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -113,4 +113,12 @@ class Check
       client_age
     end
   end
+
+  def under_eighteen_controlled_clr?
+    Steps::Logic.controlled_clr?(session_data)
+  end
+
+  def under_eighteen_no_means_test_required?
+    Steps::Logic.under_eighteen_no_means_test_required?(session_data)
+  end
 end

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -114,10 +114,6 @@ class Check
     end
   end
 
-  def under_eighteen_controlled_clr?
-    Steps::Logic.controlled_clr?(session_data)
-  end
-
   def under_eighteen_no_means_test_required?
     Steps::Logic.under_eighteen_no_means_test_required?(session_data)
   end

--- a/app/views/checks/end_of_journey.html.slim
+++ b/app/views/checks/end_of_journey.html.slim
@@ -1,4 +1,3 @@
-- under_18_and_does_not_need_means_test = @check.under_eighteen_controlled_clr? || @check.under_eighteen_no_means_test_required?
 - content_for :page_title
   = t(".title")
 - content_for :back do
@@ -17,7 +16,7 @@
     li = t(".add_client_details")
     li = t(".sign_the_form")
 
-  - if under_18_and_does_not_need_means_test
+  - if @check.under_eighteen_no_means_test_required?
     h3.govuk-heading-s = t(".keep_the_evidence_for_under_18")
     p.govuk-text = t(".file_may_be_audited")
   - else

--- a/app/views/checks/end_of_journey.html.slim
+++ b/app/views/checks/end_of_journey.html.slim
@@ -1,3 +1,4 @@
+- under_18_and_does_not_need_means_test = @check.under_eighteen_controlled_clr? || @check.under_eighteen_no_means_test_required?
 - content_for :page_title
   = t(".title")
 - content_for :back do
@@ -16,12 +17,16 @@
     li = t(".add_client_details")
     li = t(".sign_the_form")
 
-  h3.govuk-heading-s = t(".gather_evidence")
-  p.govuk-text = t(".keep_evidence")
-  = govuk_details(summary_text: t("results.show.evidence_needed")) do
-    = render "results/evidence"
+  - if under_18_and_does_not_need_means_test
+    h3.govuk-heading-s = t(".keep_the_evidence_for_under_18")
+    p.govuk-text = t(".file_may_be_audited")
+  - else
+    h3.govuk-heading-s = t(".gather_evidence")
+    p.govuk-text = t(".keep_evidence")
+    = govuk_details(summary_text: t("results.show.evidence_needed")) do
+      = render "results/evidence"
 
-  h3.govuk-heading-s = t(".keep_the_evidence")
-  p.govuk-text = t(".file_may_be_audited")
+    h3.govuk-heading-s = t(".keep_the_evidence")
+    p.govuk-text = t(".file_may_be_audited")
 
 = render "shared/question_sidebar", level_of_help: @check.level_of_help, links: {}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1712,6 +1712,7 @@ en:
       gather_evidence: 2. Gather your client’s evidence
       keep_evidence: You will need to keep evidence of means provided by your client along with the controlled work form.
       keep_the_evidence: 3. Keep the evidence together with the controlled work form in your records
+      keep_the_evidence_for_under_18: 2. Keep the controlled work form in your records
       file_may_be_audited: Your client’s file may be audited or assessed by the LAA at a later date.
   results:
     show:


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1278)

## What changed and why

- Removing references to evidence gathering and 'evidence you might need' on ‘You’ve reached the end of this service' screen in the controlled work flow when a client is under 18 and doesn’t need a means test. 

## Guidance to review

N/A

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
