### PR TITLE
EL-1290 speed up testing

### DIFF
--- a/spec/system/accessibility_spec.rb
+++ b/spec/system/accessibility_spec.rb
@@ -78,19 +78,17 @@ RSpec.describe "Accessibility" do
       allow(CfeConnection).to receive(:state_benefit_types).and_return([])
     end
 
-    %w[controlled certificated].each do |level_of_help|
-      it "has no AXE-detectable accessibility issues on any page" do
-        start_assessment
-        fill_in_level_of_help_screen choice: level_of_help
-        assessment_code = current_path.split("/").reverse.second
+    it "has no AXE-detectable accessibility issues on any page", :slow do
+      start_assessment
+      fill_in_level_of_help_screen choice: "certificated"
+      assessment_code = current_path.split("/").reverse.second
 
-        Steps::Helper.all_possible_steps.each do |step|
-          visit form_path(step, assessment_code)
+      Steps::Helper.all_possible_steps.each do |step|
+        visit form_path(step, assessment_code)
 
-          # govuk components deliberately break ARIA rules by putting 'aria-expanded' attributes on inputs
-          # C.F. https://github.com/alphagov/govuk-frontend/issues/979
-          expect(page).to be_axe_clean.skipping("aria-allowed-attr")
-        end
+        # govuk components deliberately break ARIA rules by putting 'aria-expanded' attributes on inputs
+        # C.F. https://github.com/alphagov/govuk-frontend/issues/979
+        expect(page).to be_axe_clean.skipping("aria-allowed-attr")
       end
     end
   end
@@ -105,7 +103,7 @@ RSpec.describe "Accessibility" do
       click_on "Submit"
     end
 
-    it "has no AXE-detectable accessibility issues" do
+    it "has no AXE-detectable accessibility issues", :slow do
       # govuk accordions deliberately break ARIA rules by putting 'aria-labelledBy' without a role
       # C.F. https://github.com/alphagov/govuk-frontend/issues/2472#issuecomment-1398629391
       # govuk components deliberately break ARIA rules by putting 'aria-expanded' attributes on inputs

--- a/spec/system/add_another_spec.rb
+++ b/spec/system/add_another_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Add another JS" do
       expect(page).to have_content "Enter the estimated value of the vehicle"
     end
 
-    it "shows numbered error messages if there are more than 1 on the page" do
+    it "shows numbered error messages if there are more than 1 on the page", :slow do
       fill_in "1-vehicle-value", with: "123"
       choose "No", name: "vehicle_model[items][1][vehicle_pcp]"
       choose "No", name: "vehicle_model[items][1][vehicle_over_3_years_ago]"
@@ -30,7 +30,7 @@ RSpec.describe "Add another JS" do
       expect(page).to have_content "Enter the estimated value of vehicle 2"
     end
 
-    it "lets me add multiple vehicles" do
+    it "lets me add multiple vehicles", :slow do
       fill_in "1-vehicle-value", with: "123"
       choose "No", name: "vehicle_model[items][1][vehicle_pcp]"
       choose "No", name: "vehicle_model[items][1][vehicle_over_3_years_ago]"
@@ -60,7 +60,7 @@ RSpec.describe "Add another JS" do
       expect(session_contents.dig("vehicles", 1, "vehicle_in_dispute")).to eq true
     end
 
-    it "lets me remove a vehicle" do
+    it "lets me remove a vehicle", :slow do
       fill_in "1-vehicle-value", with: "123"
       choose "No", name: "vehicle_model[items][1][vehicle_pcp]"
       choose "No", name: "vehicle_model[items][1][vehicle_over_3_years_ago]"
@@ -90,7 +90,7 @@ RSpec.describe "Add another JS" do
       expect(session_contents.dig("vehicles", 1, "vehicle_value")).to eq 789
     end
 
-    it "removes error messages pertaining to a removed item" do
+    it "removes error messages pertaining to a removed item", :slow do
       fill_in "1-vehicle-value", with: "123"
       choose "No", name: "vehicle_model[items][1][vehicle_pcp]"
       choose "No", name: "vehicle_model[items][1][vehicle_over_3_years_ago]"
@@ -107,7 +107,7 @@ RSpec.describe "Add another JS" do
       expect(page).not_to have_content "Enter the estimated value of vehicle 2"
     end
 
-    it "rewords error messages pertaining items that come after a removed item" do
+    it "rewords error messages pertaining items that come after a removed item", :slow do
       fill_in "1-vehicle-value", with: "123"
       choose "No", name: "vehicle_model[items][1][vehicle_pcp]"
       choose "No", name: "vehicle_model[items][1][vehicle_over_3_years_ago]"
@@ -137,7 +137,7 @@ RSpec.describe "Add another JS" do
       fill_in_additional_property_screen(choice: "Yes, owned outright")
     end
 
-    it "applies conditional validation appropriately" do
+    it "applies conditional validation appropriately", :slow do
       fill_in "1-house-value", with: "123"
       fill_in "1-percentage-owned", with: "100"
       click_on "Add another property"

--- a/spec/system/feedback_spec.rb
+++ b/spec/system/feedback_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Feedback component" do
     end
 
     context "when on the results page" do
-      it "I can successfully submit satisfaction feedback" do
+      it "I can successfully submit satisfaction feedback", :slow do
         start_assessment
         fill_in_forms_until(:check_answers)
         click_on "Submit"
@@ -31,7 +31,7 @@ RSpec.describe "Feedback component" do
     end
 
     context "when on the results page, with end_of_journey_flag enabled", :end_of_journey_flag do
-      it "I can successfully submit freetext feedback" do
+      it "I can successfully submit freetext feedback", :slow do
         start_assessment
         fill_in_level_of_help_screen(choice: "Civil controlled work or family mediation")
         fill_in_forms_until(:check_answers)
@@ -46,7 +46,7 @@ RSpec.describe "Feedback component" do
     end
 
     context "when on the CW form selection page" do
-      it "I can successfully submit satisfaction feedback" do
+      it "I can successfully submit satisfaction feedback", :slow do
         start_assessment
         fill_in_level_of_help_screen(choice: "Civil controlled work or family mediation")
         fill_in_forms_until(:check_answers)
@@ -64,7 +64,7 @@ RSpec.describe "Feedback component" do
   describe "Freetext feedback" do
     describe "pages within the question flow" do
       context "when on the check answers page" do
-        it "I can submit freetext feedback" do
+        it "I can submit freetext feedback", :slow do
           start_assessment
           fill_in_forms_until(:check_answers)
           expect(page).to have_content("Give feedback on this page")
@@ -75,7 +75,7 @@ RSpec.describe "Feedback component" do
           expect(FreetextFeedback.find_by(text: "some feedback!", page: "check_answers_checks", level_of_help: "certificated")).not_to be_nil
         end
 
-        it "I can cancel my freetext feedback" do
+        it "I can cancel my freetext feedback", :slow do
           start_assessment
           fill_in_forms_until(:check_answers)
           expect(page).to have_content("Give feedback on this page")
@@ -88,7 +88,7 @@ RSpec.describe "Feedback component" do
           expect(FreetextFeedback.count).to be(0)
         end
 
-        it "I'm presented with prompt, when I don't enter any text" do
+        it "I'm presented with prompt, when I don't enter any text", :slow do
           start_assessment
           fill_in_forms_until(:check_answers)
           expect(page).to have_content("Give feedback on this page")


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1290)

## What changed and why

added a `:slow` tag to 12 tests, all of which were taking longer than 3 seconds each.
removed one journey from the AXE tests so now we only check `certificated`. The `certificated` AXE test takes longer but covers more of the journey, however if we feel that as we reuse components, nothing would be missed if we used `controlled` I am happy to switch to that journey. 

to run the tests locally without the slow tests: 
`bundle exec rspec -tag=~slow`

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
