### PR TITLE
EL-1255: Under-18 results

### DIFF
--- a/app/lib/steps/logic.rb
+++ b/app/lib/steps/logic.rb
@@ -33,6 +33,10 @@ module Steps
         return true unless controlled?(session_data)
         return true if controlled_clr?(session_data)
 
+        not_aggregated_no_income_low_capital?(session_data)
+      end
+
+      def not_aggregated_no_income_low_capital?(session_data)
         aggregated_means?(session_data) == false && under_eighteen_regular_income?(session_data) == false && under_eighteen_assets?(session_data) == false
       end
 

--- a/app/models/calculation_result.rb
+++ b/app/models/calculation_result.rb
@@ -31,7 +31,7 @@ class CalculationResult
   end
 
   def calculated?(section)
-    api_response.dig(:result_summary, section, :proceeding_types).select { VALID_OVERALL_RESULTS.include?(_1[:result]) }.any?
+    api_response.dig(:result_summary, section, :proceeding_types).any? { VALID_OVERALL_RESULTS.include?(_1[:result]) }
   end
 
   def ineligible?(section)

--- a/app/models/calculation_result.rb
+++ b/app/models/calculation_result.rb
@@ -19,6 +19,7 @@ class CalculationResult
       # We believe that those circumstances can never be reached via CCQ.
       # However we want to safeguard against CFE doing something unexpected.
       result = api_response.dig(:result_summary, :overall_result, :result)
+
       raise "Unhandled CFE result: #{result}" unless VALID_OVERALL_RESULTS.include?(result)
 
       result
@@ -30,7 +31,7 @@ class CalculationResult
   end
 
   def calculated?(section)
-    api_response.dig(:result_summary, section, :proceeding_types).all? { VALID_OVERALL_RESULTS.include?(_1[:result]) }
+    api_response.dig(:result_summary, section, :proceeding_types).select { VALID_OVERALL_RESULTS.include?(_1[:result]) }.any?
   end
 
   def ineligible?(section)

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -82,10 +82,6 @@ class Check
     end
   end
 
-  def employed?
-    Steps::Logic.employed?(session_data)
-  end
-
   def partner_employed?
     Steps::Logic.partner_employed?(session_data)
   end
@@ -116,6 +112,10 @@ class Check
 
   def under_eighteen_no_means_test_required?
     Steps::Logic.under_eighteen_no_means_test_required?(session_data)
+  end
+
+  def not_aggregated_no_income_low_capital?
+    Steps::Logic.not_aggregated_no_income_low_capital?(session_data)
   end
 
   def under_eighteen?

--- a/app/services/cfe/applicant_payload_service.rb
+++ b/app/services/cfe/applicant_payload_service.rb
@@ -5,30 +5,13 @@ module Cfe
     end
 
     def build_applicant
-      if relevant_form?(:asylum_support)
-        asylum_support_form = instantiate_form(AsylumSupportForm)
-        if asylum_support_form.asylum_support
-          return {
-            date_of_birth: 50.years.ago.to_date,
-            has_partner_opponent: false,
-            receives_qualifying_benefit: false,
-            employed: false,
-            receives_asylum_support: true,
-          }
-        end
-      end
-
-      applicant_form = instantiate_form(ApplicantForm)
-      {
-        date_of_birth: date_of_birth(applicant_form),
-        has_partner_opponent: false,
-        receives_qualifying_benefit: applicant_form.passporting || false,
-        employed: check.employed?,
-        receives_asylum_support: false,
-      }
+      ret = { date_of_birth: }
+      ret[:receives_qualifying_benefit] = check.passporting if relevant_form?(:applicant)
+      ret[:receives_asylum_support] = check.asylum_support if relevant_form?(:asylum_support)
+      ret
     end
 
-    def date_of_birth(applicant_form)
+    def date_of_birth
       if relevant_form?(:client_age)
         client_age_form = instantiate_form(ClientAgeForm)
         case client_age_form.client_age
@@ -40,7 +23,7 @@ module Cfe
           50.years.ago.to_date
         end
       else
-        applicant_form.over_60 ? 70.years.ago.to_date : 50.years.ago.to_date
+        check.over_60 ? 70.years.ago.to_date : 50.years.ago.to_date
       end
     end
   end

--- a/app/services/cfe/assessment_payload_service.rb
+++ b/app/services/cfe/assessment_payload_service.rb
@@ -6,6 +6,9 @@ module Cfe
         submission_date: Time.zone.today,
         level_of_help: form.level_of_help,
       }
+
+      assessment[:controlled_legal_representation] = check.controlled_legal_representation if relevant_form?(:under_18_clr)
+      assessment[:not_aggregated_no_income_low_capital] = check.not_aggregated_no_income_low_capital? if relevant_form?(:aggregated_means)
       payload[:assessment] = assessment
     end
   end

--- a/app/services/cfe/proceedings_payload_service.rb
+++ b/app/services/cfe/proceedings_payload_service.rb
@@ -2,11 +2,11 @@ module Cfe
   class ProceedingsPayloadService < BaseService
     PROCEEDING_TYPES = { "immigration" => "IM030", "asylum" => "IA031", "other" => "SE003", "domestic_abuse" => "DA001" }.freeze
     def call
-      payload[:proceeding_types] = if relevant_form?(:domestic_abuse_applicant)
-                                     payload_from_certificated_journey
-                                   else
-                                     payload_from_immigration_and_asylum_choices
-                                   end
+      if relevant_form?(:domestic_abuse_applicant)
+        payload[:proceeding_types] = payload_from_certificated_journey
+      elsif relevant_form?(:immigration_or_asylum)
+        payload[:proceeding_types] = payload_from_immigration_and_asylum_choices
+      end
     end
 
     def payload_from_certificated_journey

--- a/app/views/checks/_check_answers_table.html.slim
+++ b/app/views/checks/_check_answers_table.html.slim
@@ -33,7 +33,7 @@
                 = render "checks/check_answer",
                           label_text: t("checks.check_answers.#{field.label}"),
                           value_text: yes_no_boolean(field.value),
-                          screen: field.screen
+                          screen: (field.screen if change_links)
               - when "number_or_text"
                 = render "checks/check_answer",
                           label_text: t("checks.check_answers.#{field.label}"),
@@ -47,7 +47,7 @@
                 = render "checks/check_answer",
                           label_text: t("checks.check_answers.#{field.label}"),
                           value_text: t("checks.check_answers.#{value_key}"),
-                          screen: field.screen
+                          screen: (field.screen if change_links)
               - when "frequency"
                 = render "checks/check_answer",
                           label_text: t("checks.check_answers.#{field.label}"),

--- a/app/views/results/_result_panel_content.html.slim
+++ b/app/views/results/_result_panel_content.html.slim
@@ -1,4 +1,6 @@
-- if @check.asylum_support
+- if @check.under_eighteen_no_means_test_required?
+  = render "under_eighteen"
+- elsif @check.asylum_support
   = render "asylum_support_#{@model.level_of_help}_eligible"
 - else
   = render "#{@model.level_of_help}_#{@model.decision}"

--- a/app/views/results/_under_eighteen.html.slim
+++ b/app/views/results/_under_eighteen.html.slim
@@ -1,0 +1,9 @@
+ruby:
+  level_of_help = if @check.controlled?
+                    @check.controlled_legal_representation ? "controlled_clr" : "controlled"
+                  else
+                    "certificated"
+                  end
+= pdf_friendly_h1(t("results.show.under_eighteen_#{level_of_help}_header"), @is_pdf)
+
+= pdf_friendly_paragraphs(t("results.show.under_eighteen_#{level_of_help}_paragraphs"), @is_pdf)

--- a/app/views/results/_under_eighteen_next_steps.html.slim
+++ b/app/views/results/_under_eighteen_next_steps.html.slim
@@ -1,0 +1,12 @@
+h2.govuk-heading-m = t("results.show.save_results")
+p.govuk-body = t("results.show.save_results_intro")
+ul.govuk-list.govuk-list--bullet
+  - t("results.show.save_results_bullets_no_means_test").each
+    li = _1
+.govuk-button-group
+  = link_to t("results.show.save_as_pdf"),
+        download_result_path(params[:assessment_code]),
+        target: "_blank", rel: "noopener", class: "govuk-button govuk-button--secondary"
+
+= pdf_friendly_h2(t("results.show.what_happens_next"), "m", @is_pdf)
+= pdf_friendly_p_element(t("results.show.next_steps_paragraph_1"), @is_pdf)

--- a/app/views/results/_under_eighteen_next_steps.html.slim
+++ b/app/views/results/_under_eighteen_next_steps.html.slim
@@ -1,12 +1,13 @@
-h2.govuk-heading-m = t("results.show.save_results")
-p.govuk-body = t("results.show.save_results_intro")
-ul.govuk-list.govuk-list--bullet
-  - t("results.show.save_results_bullets_no_means_test").each
-    li = _1
-.govuk-button-group
-  = link_to t("results.show.save_as_pdf"),
-        download_result_path(params[:assessment_code]),
-        target: "_blank", rel: "noopener", class: "govuk-button govuk-button--secondary"
+- if download_option
+  h2.govuk-heading-m = t("results.show.save_results")
+  p.govuk-body = t("results.show.save_results_intro")
+  ul.govuk-list.govuk-list--bullet
+    - t("results.show.save_results_bullets_no_means_test").each
+      li = _1
+  .govuk-button-group
+    = link_to t("results.show.save_as_pdf"),
+          download_result_path(params[:assessment_code]),
+          target: "_blank", rel: "noopener", class: "govuk-button govuk-button--secondary"
 
 = pdf_friendly_h2(t("results.show.what_happens_next"), "m", @is_pdf)
 = pdf_friendly_p_element(t("results.show.next_steps_paragraph_1"), @is_pdf)

--- a/app/views/results/download.html.slim
+++ b/app/views/results/download.html.slim
@@ -25,7 +25,9 @@
       - %i[gross_income disposable_income capital].each
         = render("summary", section: _1, links: false) if @model.calculated?(_1)
 
-  - if @model.level_of_help == "certificated"
+  - if @check.under_eighteen_no_means_test_required?
+    = render "under_eighteen_next_steps"
+  - elsif @model.level_of_help == "certificated"
     = render "certificated_next_steps"
     = pdf_friendly_h2(t("results.show.evidence_needed"), "m", @is_pdf)
     = render "evidence"

--- a/app/views/results/download.html.slim
+++ b/app/views/results/download.html.slim
@@ -26,7 +26,7 @@
         = render("summary", section: _1, links: false) if @model.calculated?(_1)
 
   - if @check.under_eighteen_no_means_test_required?
-    = render "under_eighteen_next_steps"
+    = render "under_eighteen_next_steps", download_option: false
   - elsif @model.level_of_help == "certificated"
     = render "certificated_next_steps"
     = pdf_friendly_h2(t("results.show.evidence_needed"), "m", @is_pdf)

--- a/app/views/results/show.html.slim
+++ b/app/views/results/show.html.slim
@@ -45,7 +45,7 @@
               class: "govuk-button", data: { module: "govuk-button" }
 
   - elsif @check.under_eighteen_no_means_test_required?
-    = render "under_eighteen_next_steps"
+    = render "under_eighteen_next_steps", download_option: true
   - elsif @model.level_of_help == "certificated"
     = render "certificated_next_steps"
 

--- a/app/views/results/show.html.slim
+++ b/app/views/results/show.html.slim
@@ -22,9 +22,9 @@
   - if @journey_continues_on_another_page
     h2.govuk-heading-m = t(".save_results")
     p.govuk-body = t(".save_results_intro")
-    - if @check.asylum_support
+    - if @check.asylum_support || @check.under_eighteen_no_means_test_required?
       ul.govuk-list.govuk-list--bullet
-        - t(".save_results_bullets_asylum").each
+        - t(".save_results_bullets_no_means_test").each
           li = _1
     - else
       ul.govuk-list.govuk-list--bullet
@@ -37,20 +37,22 @@
             target: "_blank", rel: "noopener", class: "govuk-button govuk-button--secondary"
 
     h2.govuk-heading-m = t(".complete_a_cw_form")
-    p.govuk-body = t(".complete_a_cw_form_paragraph")
+    p.govuk-body = t(".complete_a_cw_form_paragraph#{'_under_eighteen' if @check.under_eighteen_no_means_test_required?}")
     h2.govuk-heading-s = t(".download_a_cw_form_header")
 
     = link_to t("results.show.continue_to_cw"),
               controlled_work_document_selection_path(assessment_code: params[:assessment_code]),
               class: "govuk-button", data: { module: "govuk-button" }
 
-  - if @model.level_of_help == "certificated"
+  - elsif @check.under_eighteen_no_means_test_required?
+    = render "under_eighteen_next_steps"
+  - elsif @model.level_of_help == "certificated"
     = render "certificated_next_steps"
 
     = govuk_details(summary_text: t(".evidence_needed")) do
       = render "evidence"
 
-  - if @model.level_of_help == "controlled" && @model.decision == "ineligible"
+  - elsif @model.level_of_help == "controlled" && @model.decision == "ineligible"
     h2.govuk-heading-m = t(".what_happens_next")
     p.govuk-body = t(".what_happens_next_controlled_ineligible_next_step")
 
@@ -80,7 +82,7 @@
         - accordion.with_section(heading_text: t(".capital_calculation"))
           = render "capital_table", caption_size: "m"
 
-  - unless @journey_continues_on_another_page
+  - unless @journey_continues_on_another_page || @check.under_eighteen_no_means_test_required?
     .govuk-button-group
       = link_to t(".save_as_pdf"), download_result_path(params[:assessment_code]),
                                     target: "_blank", rel: "noopener", class: "govuk-button"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1762,6 +1762,21 @@ en:
         - Your client qualifies financially for civil legal aid, based on the information you have entered. Before you (or a provider of advice or services funded by legal aid) proceed with your client’s case, it must also be within scope for legal aid and satisfy the relevant merits criteria set out in the relevant legislation and guidance.
         - You told us your client is in receipt of Section 4 or Section 95 Asylum Support. This makes them automatically financially eligible for civil controlled work relating to legal help and help at court for immigration and asylum proceedings, as well as controlled legal representation in the Immigration and Asylum chamber of the first tier or upper tribunal without income, outgoing and capital calculations.
         - This assessment has been made in line with the latest version of the Lord Chancellor’s Guidance on Determining Eligibility for Controlled Work.
+      under_eighteen_certificated_header: Your client qualifies for civil legal aid without a means test, for certificated work
+      under_eighteen_certificated_paragraphs:
+        - Your client qualifies for civil legal aid without a means test, based on the information you have entered. Before you (or a provider of advice or services funded by legal aid) proceed with your client’s case, it must also be within scope for legal aid and satisfy the relevant merits criteria set out in the relevant legislation and guidance.
+        - You told us your client is under 18. This makes them automatically eligible for civil certificated or licensed legal work without a means test.
+        - These calculations were made in line with the latest version of the Lord Chancellor's Guidance on Determining Financial Eligibility for Certificated Work.
+      under_eighteen_controlled_header: Your client qualifies for civil legal aid without a full means test, for controlled work and family mediation
+      under_eighteen_controlled_paragraphs:
+        - Your client qualifies for civil legal aid without a full means test, based on the information you have entered. Before you (or a provider of advice or services funded by legal aid) proceed with your client’s case, it must also be within scope for legal aid and satisfy the relevant merits criteria set out in the relevant legislation and guidance.
+        - You told us your client is under 18, their means cannot be aggregated with another person’s, they don’t have assets worth £2,500 or more, and they don’t get regular income. This makes them eligible for controlled work and family mediation without a full means test.
+        - This assessment has been made in line with the latest version of the Lord Chancellor's Guidance on Determining Financial Eligibility for Controlled Work.
+      under_eighteen_controlled_clr_header: Your client qualifies for civil legal aid without a means test, for controlled legal representation
+      under_eighteen_controlled_clr_paragraphs:
+        - Your client qualifies for civil legal aid without a means test, based on the information you have entered. Before you (or a provider of advice or services funded by legal aid) proceed with your client’s case, it must also be within scope for legal aid and satisfy the relevant merits criteria set out in the relevant legislation and guidance.
+        - You told us your client is under 18. This makes them automatically eligible for controlled legal representation (CLR) without a means test.
+        - This assessment has been made in line with the latest version of the Lord Chancellor's Guidance on Determining Financial Eligibility for Controlled Work.
       save_results: Save results and answers as a PDF
       save_results_intro: 'The PDF will include:'
       save_results_bullets:
@@ -1769,11 +1784,12 @@ en:
         - your client’s key eligibility totals
         - how we calculated your client’s key eligibility totals
         - the answers you input into this service
-      save_results_bullets_asylum:
+      save_results_bullets_no_means_test:
         - the eligibility declaration
         - the answers you input into this service
       complete_a_cw_form: Complete a controlled work form
       complete_a_cw_form_paragraph: You will need to complete the relevant controlled work form and keep for your records, along with any evidence provided by your client. Your client’s file may be audited and assessed by the LAA at a later date.
+      complete_a_cw_form_paragraph_under_eighteen: You will need to complete the relevant controlled work form and keep for your records. Your client’s file may be audited and assessed by the LAA at a later date.
       download_a_cw_form_header: Download a controlled work form with your answers included
       what_happens_next: What happens next
       what_happens_next_controlled_ineligible_next_step: You may wish to discuss your client’s options, for example they can pay for legal support or get advice from a charity or advice organisation.

--- a/spec/end_to_end/asylum_support_spec.rb
+++ b/spec/end_to_end/asylum_support_spec.rb
@@ -24,9 +24,6 @@ RSpec.describe "Asylum support checks", type: :feature do
         expect(parsed["proceeding_types"]).to eq([{ "ccms_code" => "IA031", "client_involvement_type" => "A" }])
         expect(parsed["applicant"]).to eq({
           "date_of_birth" => "1973-02-15",
-          "has_partner_opponent" => false,
-          "receives_qualifying_benefit" => false,
-          "employed" => false,
           "receives_asylum_support" => true,
         })
       }.to_return(

--- a/spec/end_to_end/passporting_spec.rb
+++ b/spec/end_to_end/passporting_spec.rb
@@ -38,10 +38,7 @@ RSpec.describe "passported check", type: :feature do
         expect(parsed["proceeding_types"]).to be_present
         expect(parsed["applicant"]).to eq({
           "date_of_birth" => "1973-02-15",
-          "has_partner_opponent" => false,
           "receives_qualifying_benefit" => true,
-          "receives_asylum_support" => false,
-          "employed" => false,
         })
         expect(parsed["vehicles"]).to eq([{
           "value" => 1.0,

--- a/spec/end_to_end/under_eighteen_spec.rb
+++ b/spec/end_to_end/under_eighteen_spec.rb
@@ -1,0 +1,142 @@
+require "rails_helper"
+
+RSpec.describe "Under-18 checks", :under_eighteen_flag do
+  before do
+    start_assessment
+    fill_in_client_age_screen(choice: "Under 18")
+  end
+
+  describe "certificated check", type: :feature do
+    before do
+      fill_in_level_of_help_screen(choice: "Civil certificated")
+    end
+
+    context "with stubbing" do
+      let(:fixed_arbitrary_date) { Date.new(2023, 2, 15) }
+
+      before { travel_to fixed_arbitrary_date }
+
+      it "sends the right data to CFE for certificated work" do
+        stubbed_assessment_call = stub_request(:post, %r{assessments\z}).with { |request|
+          parsed = JSON.parse(request.body)
+          expect(parsed["assessment"]).to eq({
+            "submission_date" => "2023-02-15",
+            "level_of_help" => "certificated",
+          })
+          expect(parsed["proceeding_types"]).not_to be_present
+          expect(parsed["applicant"]).to eq({
+            "date_of_birth" => "2006-02-15",
+          })
+        }.to_return(
+          body: FactoryBot.build(:api_result, eligible: "eligible").to_json,
+          headers: { "Content-Type" => "application/json" },
+        )
+
+        click_on "Submit"
+        expect(stubbed_assessment_call).to have_been_requested
+      end
+    end
+
+    context "when hitting the API", :end2end do
+      it "renders content" do
+        click_on "Submit"
+        expect(page).to have_content("Your client qualifies for civil legal aid without a means test, for certificated work")
+        expect(page).not_to have_content("Income calculation")
+        expect(page).not_to have_content("Outgoings calculation")
+        expect(page).not_to have_content("Capital calculation")
+      end
+    end
+  end
+
+  describe "controlled legal representation check", type: :feature do
+    before do
+      fill_in_level_of_help_screen(choice: "Civil controlled")
+      fill_in_under_18_controlled_legal_rep_screen(choice: "Yes")
+    end
+
+    context "with stubbing" do
+      let(:fixed_arbitrary_date) { Date.new(2023, 2, 15) }
+
+      before { travel_to fixed_arbitrary_date }
+
+      it "sends the right data to CFE for certificated work" do
+        stubbed_assessment_call = stub_request(:post, %r{assessments\z}).with { |request|
+          parsed = JSON.parse(request.body)
+          expect(parsed["assessment"]).to eq({
+            "submission_date" => "2023-02-15",
+            "level_of_help" => "controlled",
+            "controlled_legal_representation" => true,
+          })
+          expect(parsed["proceeding_types"]).not_to be_present
+          expect(parsed["applicant"]).to eq({
+            "date_of_birth" => "2006-02-15",
+          })
+        }.to_return(
+          body: FactoryBot.build(:api_result, eligible: "eligible").to_json,
+          headers: { "Content-Type" => "application/json" },
+        )
+
+        click_on "Submit"
+        expect(stubbed_assessment_call).to have_been_requested
+      end
+    end
+
+    context "when hitting the API", :end2end do
+      it "renders content" do
+        click_on "Submit"
+        expect(page).to have_content("Your client qualifies for civil legal aid without a means test, for controlled legal representation")
+        expect(page).not_to have_content("Income calculation")
+        expect(page).not_to have_content("Outgoings calculation")
+        expect(page).not_to have_content("Capital calculation")
+      end
+    end
+  end
+
+  describe "non-means-tested controlled check", type: :feature do
+    before do
+      fill_in_level_of_help_screen(choice: "Civil controlled")
+      fill_in_under_18_controlled_legal_rep_screen(choice: "No")
+      fill_in_aggregated_means_screen(choice: "No")
+      fill_in_regular_income_screen(choice: "No")
+      fill_in_under_eighteen_assets_screen(choice: "No")
+    end
+
+    context "with stubbing" do
+      let(:fixed_arbitrary_date) { Date.new(2023, 2, 15) }
+
+      before { travel_to fixed_arbitrary_date }
+
+      it "sends the right data to CFE for certificated work" do
+        stubbed_assessment_call = stub_request(:post, %r{assessments\z}).with { |request|
+          parsed = JSON.parse(request.body)
+          expect(parsed["assessment"]).to eq({
+            "submission_date" => "2023-02-15",
+            "level_of_help" => "controlled",
+            "controlled_legal_representation" => false,
+            "not_aggregated_no_income_low_capital" => true,
+          })
+          expect(parsed["proceeding_types"]).not_to be_present
+          expect(parsed["applicant"]).to eq({
+            "date_of_birth" => "2006-02-15",
+          })
+        }.to_return(
+          body: FactoryBot.build(:api_result, eligible: "eligible").to_json,
+          headers: { "Content-Type" => "application/json" },
+        )
+
+        click_on "Submit"
+        expect(stubbed_assessment_call).to have_been_requested
+      end
+    end
+
+    context "when hitting the API", :end2end do
+      it "renders content" do
+        click_on "Submit"
+        expect(page).to have_content("Your client qualifies for civil legal aid without a full means test, for controlled work and family mediation")
+        expect(page).not_to have_content("Income calculation")
+        expect(page).not_to have_content("Outgoings calculation")
+        expect(page).not_to have_content("Capital calculation")
+      end
+    end
+  end
+end

--- a/spec/end_to_end/without_partner_spec.rb
+++ b/spec/end_to_end/without_partner_spec.rb
@@ -52,10 +52,7 @@ RSpec.describe "Certificated check without partner", type: :feature do
         expect(parsed["proceeding_types"]).to eq([{ "ccms_code" => "SE003", "client_involvement_type" => "A" }])
         expect(parsed["applicant"]).to eq({
           "date_of_birth" => "1973-02-15",
-          "employed" => true,
-          "has_partner_opponent" => false,
           "receives_qualifying_benefit" => false,
-          "receives_asylum_support" => false,
         })
         expect(parsed["dependants"]).to eq([
           { "date_of_birth" => "2006-02-15",

--- a/spec/services/cfe/applicant_payload_service_spec.rb
+++ b/spec/services/cfe/applicant_payload_service_spec.rb
@@ -5,9 +5,7 @@ RSpec.describe Cfe::ApplicantPayloadService do
   let(:session_data) do
     {
       over_60:,
-      employment_status: "unemployed",
       passporting: false,
-      partner: false,
     }.with_indifferent_access
   end
   let(:payload) { {} }
@@ -21,10 +19,7 @@ RSpec.describe Cfe::ApplicantPayloadService do
         expect(payload[:applicant]).to eq(
           {
             date_of_birth: 50.years.ago.to_date,
-            employed: false,
-            has_partner_opponent: false,
             receives_qualifying_benefit: false,
-            receives_asylum_support: false,
           },
         )
       end
@@ -38,10 +33,7 @@ RSpec.describe Cfe::ApplicantPayloadService do
         expect(payload[:applicant]).to eq(
           {
             date_of_birth: 70.years.ago.to_date,
-            employed: false,
-            has_partner_opponent: false,
             receives_qualifying_benefit: false,
-            receives_asylum_support: false,
           },
         )
       end
@@ -60,9 +52,6 @@ RSpec.describe Cfe::ApplicantPayloadService do
         expect(payload[:applicant]).to eq(
           {
             date_of_birth: 50.years.ago.to_date,
-            employed: false,
-            has_partner_opponent: false,
-            receives_qualifying_benefit: false,
             receives_asylum_support: true,
           },
         )
@@ -75,7 +64,6 @@ RSpec.describe Cfe::ApplicantPayloadService do
           immigration_or_asylum_type_upper_tribunal: "immigration_upper",
           asylum_support: false,
           over_60: false,
-          employment_status: "unemployed",
           passporting: false,
           partner: false,
         }.with_indifferent_access
@@ -86,8 +74,6 @@ RSpec.describe Cfe::ApplicantPayloadService do
         expect(payload[:applicant]).to eq(
           {
             date_of_birth: 50.years.ago.to_date,
-            employed: false,
-            has_partner_opponent: false,
             receives_qualifying_benefit: false,
             receives_asylum_support: false,
           },
@@ -102,9 +88,7 @@ RSpec.describe Cfe::ApplicantPayloadService do
           asylum_support: false,
           feature_flags: { "under_eighteen" => true },
           client_age:,
-          employment_status: "unemployed",
           passporting: false,
-          partner: false,
         }.with_indifferent_access
       end
 
@@ -116,10 +100,6 @@ RSpec.describe Cfe::ApplicantPayloadService do
           expect(payload[:applicant]).to eq(
             {
               date_of_birth: 17.years.ago.to_date,
-              employed: false,
-              has_partner_opponent: false,
-              receives_qualifying_benefit: false,
-              receives_asylum_support: false,
             },
           )
         end
@@ -133,8 +113,6 @@ RSpec.describe Cfe::ApplicantPayloadService do
           expect(payload[:applicant]).to eq(
             {
               date_of_birth: 50.years.ago.to_date,
-              employed: false,
-              has_partner_opponent: false,
               receives_qualifying_benefit: false,
               receives_asylum_support: false,
             },
@@ -150,8 +128,6 @@ RSpec.describe Cfe::ApplicantPayloadService do
           expect(payload[:applicant]).to eq(
             {
               date_of_birth: 70.years.ago.to_date,
-              employed: false,
-              has_partner_opponent: false,
               receives_qualifying_benefit: false,
               receives_asylum_support: false,
             },

--- a/spec/views/results_page/under_eighteen_content_spec.rb
+++ b/spec/views/results_page/under_eighteen_content_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+RSpec.describe "results/show.html.slim", :under_eighteen_flag do
+  describe "Result panel content" do
+    let(:calculation_result) { CalculationResult.new(session_data) }
+    let(:api_response) { FactoryBot.build(:api_result, eligible: "eligible") }
+    let(:check) { Check.new(session_data) }
+    let(:journey_continues_on_another_page) { true }
+
+    before do
+      assign(:model, calculation_result)
+      assign(:check, check)
+      assign(:journey_continues_on_another_page, journey_continues_on_another_page)
+      params[:assessment_code] = :code
+      render template: "results/show"
+    end
+
+    context "when under-18 CLR check" do
+      let(:session_data) do
+        {
+          level_of_help: "controlled",
+          client_age: "under_18",
+          controlled_legal_representation: true,
+          api_response:,
+        }.with_indifferent_access
+      end
+
+      it "displays the appropriate result panel content" do
+        expect(page_text).to include "Your client qualifies for civil legal aid without a means test, for controlled legal representation"
+      end
+
+      it "shows an appropriate PDF description" do
+        expect(page_text).to include "The PDF will include:the eligibility declarationthe answers you input into this service"
+      end
+
+      it "shows appropriate next steps" do
+        expect(page_text).to include "You will need to complete the relevant controlled work form and keep for your records. Your client’s file may be audited and assessed by the LAA at a later date."
+        expect(page_text).to include "Download a controlled work form with your answers included"
+      end
+    end
+
+    context "when under-18 non-means controlled check" do
+      let(:session_data) do
+        {
+          level_of_help: "controlled",
+          client_age: "under_18",
+          controlled_legal_representation: false,
+          aggregated_means: false,
+          regular_income: false,
+          under_eighteen_assets: false,
+          api_response:,
+        }.with_indifferent_access
+      end
+
+      it "displays the appropriate result panel content" do
+        expect(page_text).to include "Your client qualifies for civil legal aid without a full means test, for controlled work and family mediation"
+      end
+
+      it "shows an appropriate PDF description" do
+        expect(page_text).to include "The PDF will include:the eligibility declarationthe answers you input into this service"
+      end
+
+      it "shows appropriate next steps" do
+        expect(page_text).to include "You will need to complete the relevant controlled work form and keep for your records. Your client’s file may be audited and assessed by the LAA at a later date."
+        expect(page_text).to include "Download a controlled work form with your answers included"
+      end
+    end
+
+    context "when under-18 certificated check" do
+      let(:journey_continues_on_another_page) { false }
+      let(:session_data) do
+        {
+          level_of_help: "certificated",
+          client_age: "under_18",
+          api_response:,
+        }.with_indifferent_access
+      end
+
+      it "displays the appropriate result panel content" do
+        expect(page_text).to include "Your client qualifies for civil legal aid without a means test, for certificated work"
+      end
+
+      it "shows an appropriate PDF description" do
+        expect(page_text).to include "The PDF will include:the eligibility declarationthe answers you input into this service"
+      end
+
+      it "shows appropriate next steps" do
+        expect(page_text).to include "Use Apply for legal aid or CCMS to start an application for your client."
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1255)

## What changed and why

- Remove deprecated applicant params from CFE payload
- Only send proceeding type to CFE if it's relevant
- Results page can cope with absence of proceeding types
- Send new u18 params to CFE
- Add new u18-specific results page content
- New e2e tests and results page view specs

## Guidance to review

E2E tests will fail until both https://github.com/ministryofjustice/cfe-civil/pull/463 and https://github.com/ministryofjustice/cfe-civil/pull/470 are merged.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
