### PR TITLE
BUG: When forms are reordered, property isn't skipped when means test should be skipped

### DIFF
--- a/app/lib/steps/outgoings_section.rb
+++ b/app/lib/steps/outgoings_section.rb
@@ -7,7 +7,7 @@ module Steps
 
       def grouped_steps_for(session_data)
         if Steps::Logic.skip_income_questions?(session_data)
-          if FeatureFlags.enabled?(:outgoings_flow, session_data)
+          if FeatureFlags.enabled?(:outgoings_flow, session_data) && !Steps::Logic.skip_capital_questions?(session_data)
             [Steps::Group.new(:property)]
           else
             []


### PR DESCRIPTION
## What changed and why

The outgoings section was always asking the property question even in situations where capital questions should be skipped.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
