### PR TITLE
circleci - remove unused browsers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ references:
         bundle exec rake db:migrate
 
 orbs:
-  aws-cli: circleci/aws-cli@4.0.0
+  aws-cli: circleci/aws-cli@4.1.2
   aws-ecr: circleci/aws-ecr@8.2.1
   browser-tools: circleci/browser-tools@1.4.6
   jira: circleci/jira@2.1.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,8 +139,10 @@ jobs:
     executor: test-executor
     steps:
       - browser-tools/install-browser-tools:
-          chrome-version: 116.0.5845.96 # TODO: remove when chromedriver downloads are fixed
-          replace-existing-chrome: true
+          replace-existing-chrome: false
+          install-firefox: false
+          install-geckodriver: false
+          install-chromedriver: false
       - checkout
       - attach_workspace:
           at: ./

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ references:
 orbs:
   aws-cli: circleci/aws-cli@4.0.0
   aws-ecr: circleci/aws-ecr@8.2.1
-  browser-tools: circleci/browser-tools@1.4.4
+  browser-tools: circleci/browser-tools@1.4.6
   jira: circleci/jira@2.1.0
   slack: circleci/slack@4.5.2
 


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-XXX)

The circleci orb browser-tools installs a few browsers by default. we currently only use chrome. the firefox install was taking 22 seconds and we dont use it so this PR stops these unused browsers being installed.

This PR also stops specifying the version of chrome and will use an existing chrome if it is available. This may be removed as there was a chromedriver issue, and I am testing to see if this is fixed.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
