### PR TITLE
EL-1318 in circle only install required browsers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,7 @@ jobs:
       - browser-tools/install-browser-tools:
           install-firefox: false
           install-geckodriver: false
+          install-chromedriver: false
       - checkout
       - attach_workspace:
           at: ./
@@ -314,7 +315,7 @@ workflows:
           environment: ccq-uat
           context: laa-check-client-qualifies-uat
           requires:
-            - run_specs
+            - coverage
             - end2end_tests
             - linters
             - build_and_push
@@ -330,7 +331,7 @@ workflows:
           environment: ccq-staging
           context: laa-check-client-qualifies-staging
           requires:
-            - run_specs
+            - coverage
             - end2end_tests
             - linters
             - build_and_push
@@ -350,7 +351,7 @@ workflows:
           environment: ccq-production
           context: laa-check-client-qualifies-production
           requires:
-            - run_specs
+            - coverage
             - end2end_tests
             - linters
             - build_and_push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,7 @@ jobs:
     executor: test-executor
     steps:
       - browser-tools/install-browser-tools:
+          replace-existing-chrome: true
           install-firefox: false
           install-geckodriver: false
           install-chromedriver: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,9 +79,9 @@ references:
         bundle exec rake db:migrate
 
 orbs:
-  aws-cli: circleci/aws-cli@4.0.0
+  aws-cli: circleci/aws-cli@4.1.2
   aws-ecr: circleci/aws-ecr@9.0.1
-  browser-tools: circleci/browser-tools@1.4.4
+  browser-tools: circleci/browser-tools@1.4.6
   jira: circleci/jira@2.1.0
   slack: circleci/slack@4.5.2
 
@@ -139,8 +139,10 @@ jobs:
     executor: test-executor
     steps:
       - browser-tools/install-browser-tools:
-          chrome-version: 116.0.5845.96 # TODO: remove when chromedriver downloads are fixed
-          replace-existing-chrome: true
+          replace-existing-chrome: false
+          install-firefox: false
+          install-geckodriver: false
+          install-chromedriver: false
       - checkout
       - attach_workspace:
           at: ./

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,10 +139,8 @@ jobs:
     executor: test-executor
     steps:
       - browser-tools/install-browser-tools:
-          replace-existing-chrome: false
           install-firefox: false
           install-geckodriver: false
-          install-chromedriver: false
       - checkout
       - attach_workspace:
           at: ./


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1318)

The circleci orb browser-tools installs a few browsers by default. we currently only use chrome. the firefox install was taking 22 seconds and we dont use it so this PR stops these unused browsers being installed.

This PR also stops specifying the version of chrome and will use an existing chrome if it is available. The issue that required us to do this appears to have been fixed in an update to the orb

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
