### PR TITLE
reduce parallel runs to 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ jobs:
           template: basic_fail_1
           branch_pattern: main
   run_specs:
-    parallelism: 5
+    parallelism: 3
     executor: test-executor
     steps:
       - browser-tools/install-browser-tools:


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-XXX)
Reduce parallel runs to 3 to check if build and push starts sooner and to check how lomng run specs tales to see if 3 is the optimal size

b&p is unaffected by the changes to parallelisation however 3 appears to be optimal for us, the actual specs run for about a minute in each with about 1 minuteof setup for each run.
<!-- fill this in -->

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
