### PR TITLE
EL-1316: Flaky spec

### DIFF
--- a/spec/system/add_another_spec.rb
+++ b/spec/system/add_another_spec.rb
@@ -45,19 +45,21 @@ RSpec.describe "Add another JS" do
       check "This asset is a subject matter of dispute", id: "2-vehicle_in_dispute"
       click_on "Save and continue"
 
-      expect(session_contents.dig("vehicles", 0, "vehicle_value")).to eq 123
-      expect(session_contents.dig("vehicles", 0, "vehicle_pcp")).to eq false
-      expect(session_contents.dig("vehicles", 0, "vehicle_finance")).to eq nil
-      expect(session_contents.dig("vehicles", 0, "vehicle_over_3_years_ago")).to eq false
-      expect(session_contents.dig("vehicles", 0, "vehicle_in_regular_use")).to eq false
-      expect(session_contents.dig("vehicles", 0, "vehicle_in_dispute")).to eq false
+      click_on "Back"
 
-      expect(session_contents.dig("vehicles", 1, "vehicle_value")).to eq 789
-      expect(session_contents.dig("vehicles", 1, "vehicle_pcp")).to eq true
-      expect(session_contents.dig("vehicles", 1, "vehicle_finance")).to eq 456
-      expect(session_contents.dig("vehicles", 1, "vehicle_over_3_years_ago")).to eq true
-      expect(session_contents.dig("vehicles", 1, "vehicle_in_regular_use")).to eq true
-      expect(session_contents.dig("vehicles", 1, "vehicle_in_dispute")).to eq true
+      expect(find(id: "1-vehicle-value").value).to eq "123"
+      expect(find(id: "1-vehicle-pcp-false", visible: false)).to be_checked
+      expect(find(id: "1-vehicle-finance", visible: false).value).to eq ""
+      expect(find(id: "1-vehicle-over-3-years-ago-false", visible: false)).to be_checked
+      expect(find(id: "1-vehicle-in-regular-use-false", visible: false)).to be_checked
+      expect(find(id: "1-vehicle_in_dispute", visible: false)).not_to be_checked
+
+      expect(find(id: "2-vehicle-value").value).to eq "789"
+      expect(find(id: "2-vehicle-pcp", visible: false)).to be_checked
+      expect(find(id: "2-vehicle-finance", visible: false).value).to eq "456"
+      expect(find(id: "2-vehicle-over-3-years-ago", visible: false)).to be_checked
+      expect(find(id: "2-vehicle-in-regular-use", visible: false)).to be_checked
+      expect(find(id: "2-vehicle_in_dispute", visible: false)).to be_checked
     end
 
     it "lets me remove a vehicle", :slow do
@@ -86,8 +88,10 @@ RSpec.describe "Add another JS" do
 
       click_on "Save and continue"
 
-      expect(session_contents.dig("vehicles", 0, "vehicle_value")).to eq 123
-      expect(session_contents.dig("vehicles", 1, "vehicle_value")).to eq 789
+      click_on "Back"
+
+      expect(find(id: "1-vehicle-value").value).to eq "123"
+      expect(find(id: "2-vehicle-value").value).to eq "789"
     end
 
     it "removes error messages pertaining to a removed item", :slow do


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1316)

## What changed and why

Only look at page contents for session specs (because on CI, for some reason, trying to retrieve session values from `page.get_rack_session` started being flaky). This makes the system test more pure - instead of knowing that stuff is stored in the session, all it needs to know is that if you save a page of data and then go back to it, there are certain IDs of HTML input elements that should be where the information you've saved should be repopulated.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
