### PR TITLE
EL-1320: Custom docker image for `test-executor`, adding an `ENV` value for puppeteer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,10 @@ executors:
   test-executor:
     resource_class: small
     docker:
-      - image: cimg/ruby:3.2.2-browsers
+      - image: checkclientqualifiesdocker/circleci-image:latest
+        auth:
+          username: $DOCKERHUB_USER_CCQ
+          password: $DOCKERHUB_PAT_CCQ
         environment:
           VCR_RECORD_MODE: none
           COVERAGE: true
@@ -16,7 +19,7 @@ executors:
           PGHOST: localhost
           PGUSER: user
           TZ: "Europe/London"
-      - image: cimg/postgres:10.18
+      - image: cimg/postgres:11.21
         environment:
           POSTGRES_USER: user
           POSTGRES_DB: ccq_test
@@ -81,7 +84,6 @@ references:
 orbs:
   aws-cli: circleci/aws-cli@4.1.2
   aws-ecr: circleci/aws-ecr@9.0.1
-  browser-tools: circleci/browser-tools@1.4.6
   jira: circleci/jira@2.1.0
   slack: circleci/slack@4.5.2
 
@@ -138,24 +140,9 @@ jobs:
     parallelism: 3
     executor: test-executor
     steps:
-      - browser-tools/install-browser-tools:
-          replace-existing-chrome: true
-          install-firefox: false
-          install-geckodriver: false
-          install-chromedriver: false
       - checkout
       - attach_workspace:
           at: ./
-      - run:
-          name: Install Puppeteer with Chromium
-          command: |
-            yarn add puppeteer@19.2.0
-      - run:
-          name: Install PDFTK
-          command: |
-            sudo add-apt-repository --yes ppa:malteworld/ppa || true
-            sudo apt update --allow-unauthenticated || true
-            sudo apt install pdftk --allow-unauthenticated || true
       - *setup_database
       - run:
           name: Run tests

--- a/.github/workflows/browser_tools_docker_image.yml
+++ b/.github/workflows/browser_tools_docker_image.yml
@@ -1,7 +1,7 @@
 name: "Generate browsertools docker image"
 on:
   schedule:
-    - cron:  '*/30 * * * *'
+    - cron:  '15 5 * * 1-5'
   workflow_dispatch:
 jobs:
   build-push:
@@ -10,12 +10,12 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_PAT }}
-      - uses: actions/checkout@v4
+          username: ${{ secrets.DOCKERHUB_USER_CCQ }}
+          password: ${{ secrets.DOCKERHUB_PAT_CCQ }}
+      - uses: actions/checkout@v3
       - name: Build the Docker image
         run: |
-          docker build . --file ./Dockerfile_browser_tools.dockerfile --tag ccq/browser-image-setup
+          docker build -f ./Dockerfile_browser_tools.dockerfile . -t checkclientqualifiesdocker/circleci-image:latest
       - name: Push the Docker image
         run: |
-          docker push ccq/browser-image-setup
+          docker push checkclientqualifiesdocker/circleci-image:latest

--- a/Dockerfile_browser_tools.dockerfile
+++ b/Dockerfile_browser_tools.dockerfile
@@ -11,9 +11,8 @@ RUN npx puppeteer browsers install chrome
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/home/circleci/.cache/puppeteer/chrome/linux-121.0.6167.85/chrome-linux64/chrome
 
-# Install Puppeteer with Chromium
-# Chromium version 119.0.6045.105 is mapped to Puppeteer version 21.5.0, as per documentation -> https://pptr.dev/chromium-support
-RUN yarn add puppeteer@21.5.0
+# Chrome version 121.0.6167.185 is mapped to Puppeteer version 21.9.0, as per documentation -> https://pptr.dev/chromium-support
+RUN yarn add puppeteer@21.9.0
 
 # Install PDFTK
 RUN sudo add-apt-repository --yes ppa:malteworld/ppa || true

--- a/Dockerfile_browser_tools.dockerfile
+++ b/Dockerfile_browser_tools.dockerfile
@@ -1,0 +1,23 @@
+# Build custom docker image for test-executor
+# Use the cimg/ruby:3.2.2-browsers image as the base image to extend out
+FROM cimg/ruby:3.2.2-browsers
+
+WORKDIR /app
+
+# Install Chrome
+RUN npx puppeteer browsers install chrome
+
+# # Tell Puppeteer to skip installing Chromium. We'll be using the installed package.
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/home/circleci/.cache/puppeteer/chrome/linux-121.0.6167.85/chrome-linux64/chrome
+
+# Install Puppeteer with Chromium
+# Chromium version 119.0.6045.105 is mapped to Puppeteer version 21.5.0, as per documentation -> https://pptr.dev/chromium-support
+RUN sudo yarn add puppeteer@21.5.0
+
+# Install PDFTK
+RUN sudo add-apt-repository --yes ppa:malteworld/ppa || true
+RUN sudo apt update --allow-unauthenticated || true
+RUN sudo apt install pdftk --allow-unauthenticated || true
+
+COPY . .

--- a/Dockerfile_browser_tools.dockerfile
+++ b/Dockerfile_browser_tools.dockerfile
@@ -13,7 +13,7 @@ ENV PUPPETEER_EXECUTABLE_PATH=/home/circleci/.cache/puppeteer/chrome/linux-121.0
 
 # Install Puppeteer with Chromium
 # Chromium version 119.0.6045.105 is mapped to Puppeteer version 21.5.0, as per documentation -> https://pptr.dev/chromium-support
-RUN sudo yarn add puppeteer@21.5.0
+RUN yarn add puppeteer@21.5.0
 
 # Install PDFTK
 RUN sudo add-apt-repository --yes ppa:malteworld/ppa || true

--- a/puppeteer.config.cjs
+++ b/puppeteer.config.cjs
@@ -1,8 +1,0 @@
-const { join } = require('path')
-
-/**
- * @type {import("puppeteer").Configuration}
- */
-module.exports = {
-  cacheDirectory: join(__dirname, '.cache', 'puppeteer')
-}


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1320)

## What changed and why

- Publishing a custom docker image, extending `cimg/ruby:3.2.2-browsers`
- This reduces `run_specs` steps for each parallelised test, by having the set-up in the executor
- Removed `puppeteer.config.cjs` which is not needed - as this was used to point to where puppeteer needing to find things in the project for it to run
- Added `ENV` variables to the docker file, which points to a constant place where puppeteer can find Chrome - as per my understanding of the [documentation](https://pptr.dev/guides/configuration) 

## Guidance to review

- Have got this to work on 2 other branches https://github.com/ministryofjustice/laa-check-client-qualifies/pull/1219/files & https://github.com/ministryofjustice/laa-check-client-qualifies/pull/1221/files - but want a fresh PR to see if this can be replicable. 
- The docker `RUN` commands have been lifted from the original steps in the `run_specs` job, and do not want to mess with them to much.  

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
