### PR TITLE
EL-1308 spike to split out interpreting Cfe data from display

### DIFF
--- a/app/models/calculation_result.rb
+++ b/app/models/calculation_result.rb
@@ -1,46 +1,27 @@
 class CalculationResult
   CFE_MAX_VALUE = 999_999_999_999
-  VALID_OVERALL_RESULTS = %w[eligible contribution_required ineligible].freeze
   Summary = Struct.new(:status, :upper_threshold, :lower_threshold, :no_upper_threshold, :no_lower_threshold, :section, keyword_init: true)
 
   include ActionView::Helpers::NumberHelper
 
   attr_reader :level_of_help
 
+  delegate :decision, :calculated?, :has_partner?, :ineligible?, :capital_items,
+           :raw_capital_contribution, :raw_income_contribution,
+           :pensioner_disregard_applied?, :smod_applied?, to: :@api_response
+
   def initialize(session_data)
-    @api_response = session_data["api_response"].deep_symbolize_keys
+    @api_response = CfeResult.new session_data["api_response"]
     @level_of_help = session_data.fetch("level_of_help", "certificated")
     @check = Check.new(session_data)
-  end
-
-  def decision
-    @decision ||= begin
-      # In some circumstances CFE can return other results, such as 'partially_eligible'.
-      # We believe that those circumstances can never be reached via CCQ.
-      # However we want to safeguard against CFE doing something unexpected.
-      result = api_response.dig(:result_summary, :overall_result, :result)
-
-      raise "Unhandled CFE result: #{result}" unless VALID_OVERALL_RESULTS.include?(result)
-
-      result
-    end
   end
 
   def any_calculations_performed?
     calculated?(:gross_income) || calculated?(:disposable_income) || calculated?(:capital)
   end
 
-  def calculated?(section)
-    api_response.dig(:result_summary, section, :proceeding_types).any? { VALID_OVERALL_RESULTS.include?(_1[:result]) }
-  end
-
-  def ineligible?(section)
-    api_response.dig(:result_summary, section, :proceeding_types).all? { _1[:result] == "ineligible" }
-  end
-
   def summary_data(section)
-    raw_thresholds = api_response.dig(:result_summary, section, :proceeding_types, 0)
-                             .slice(:upper_threshold, :lower_threshold)
+    raw_thresholds = api_response.raw_thresholds(section)
     thresholds = raw_thresholds.transform_values { monetise(_1, precision: 0) }
 
     # The HTML IDs of the various accordion sections are dynamically generated within the
@@ -56,7 +37,7 @@ class CalculationResult
                            end
     thresholds[:no_upper_threshold] = raw_thresholds[:upper_threshold] == CFE_MAX_VALUE
     thresholds[:no_lower_threshold] = raw_thresholds[:upper_threshold] == raw_thresholds[:lower_threshold]
-    case api_response.dig(:result_summary, section, :proceeding_types, 0, :result)
+    case api_response.result_for(section)
     when "ineligible"
       Summary.new(**thresholds.merge(status: "ineligible"))
     when "contribution_required"
@@ -74,77 +55,52 @@ class CalculationResult
     @check.immigration_or_asylum_type_upper_tribunal
   end
 
-  def raw_capital_contribution
-    api_response.dig(:result_summary, :overall_result, :capital_contribution)
-  end
-
   def capital_contribution
-    @capital_contribution ||= monetise(raw_capital_contribution)
-  end
-
-  def raw_income_contribution
-    api_response.dig(:result_summary, :overall_result, :income_contribution)
+    @capital_contribution ||= monetise(api_response.raw_capital_contribution)
   end
 
   def income_contribution
-    @income_contribution ||= monetise(raw_income_contribution)
+    @income_contribution ||= monetise(api_response.raw_income_contribution)
   end
 
   def total_calculated_gross_income
-    monetise(api_response.dig(:result_summary, :gross_income, :combined_total_gross_income))
+    monetise(api_response.raw_total_calculated_gross_income)
   end
 
   def gross_outgoings
-    monetise(api_response.dig(:result_summary, :disposable_income, :combined_total_outgoings_and_allowances))
+    monetise(api_response.raw_gross_outgoings)
   end
 
   def gross_income_upper_threshold
-    monetise(api_response.dig(:result_summary, :gross_income, :proceeding_types).map { |pt| pt.fetch(:upper_threshold) }.min)
+    monetise(api_response.raw_gross_income_upper_threshold)
   end
 
   def total_calculated_disposable_income
-    monetise(api_response.dig(:result_summary, :disposable_income, :combined_total_disposable_income))
+    monetise(api_response.raw_total_calculated_disposable_income)
   end
 
   def total_calculated_capital
-    # # If the pensioner_capital_disregard is applied, it is applied by CFE in full even when the disregard is
-    # # greater than the client's total capital value. This can lead to the CFE 'assessed capital' figure
-    # # being a negative number, which is unsuitable for display to the end user.
-    # # Therefore we must correct the CFE result to display a zero if it comes back negative.
-    monetise([api_response.dig(:result_summary, :capital, :combined_assessed_capital), 0].compact.max)
+    monetise(api_response.raw_total_calculated_capital)
   end
 
   def disposable_income_upper_threshold
-    monetise(api_response.dig(:result_summary, :disposable_income, :proceeding_types).map { |pt| pt.fetch(:upper_threshold) }.min)
+    monetise(api_response.raw_disposable_income_upper_threshold)
   end
 
   def capital_upper_threshold
-    monetise(api_response.dig(:result_summary, :capital, :proceeding_types).map { |pt| pt.fetch(:upper_threshold) }.min)
+    monetise(api_response.raw_capital_upper_threshold)
   end
 
   def client_assessed_capital
-    monetise(api_response.dig(:result_summary, :capital, :total_capital_with_smod))
+    monetise(api_response.raw_client_assessed_capital)
   end
 
   def partner_assessed_capital
-    monetise(api_response.dig(:result_summary, :partner_capital, :total_capital_with_smod))
+    monetise(api_response.raw_partner_assessed_capital)
   end
 
   def client_income_rows
     income_rows(prefix: "")
-  end
-
-  def has_partner?
-    @has_partner ||= api_response.dig(:assessment, :partner_capital).present?
-  end
-
-  def pensioner_disregard_applied?
-    api_response.dig(:result_summary, :capital, :pensioner_disregard_applied).positive? ||
-      api_response.dig(:result_summary, :partner_capital, :pensioner_disregard_applied)&.positive?
-  end
-
-  def smod_applied?
-    api_response.dig(:result_summary, :capital, :subject_matter_of_dispute_disregard).positive?
   end
 
   def partner_income_rows
@@ -163,8 +119,8 @@ class CalculationResult
   end
 
   def household_outgoing_rows
-    data = { housing_costs: api_response.dig(:result_summary, :disposable_income, :net_housing_costs) }
-    dependants_allowance = api_response.dig(:result_summary, :disposable_income, :dependant_allowance)
+    data = { housing_costs: api_response.disposable_income_result_row(:net_housing_costs) }
+    dependants_allowance = api_response.disposable_income_result_row(:dependant_allowance)
     data[:dependants_allowance] = dependants_allowance if @check.adult_dependants || @check.child_dependants
     data.transform_values { |v| monetise(v) }
   end
@@ -208,11 +164,7 @@ class CalculationResult
   end
 
   def client_capital_subtotal_rows
-    rows = {
-      total_capital: monetise(api_response.dig(:result_summary, :capital, :total_capital)),
-      smod_non_property_disregard: monetise(-api_response.dig(:result_summary, :capital, :disputed_non_property_disregard)),
-      pensioner_capital_disregard: monetise(-api_response.dig(:result_summary, :capital, :pensioner_disregard_applied)),
-    }
+    rows = api_response.client_capital_subtotal_rows.transform_values { |x| monetise(x) }
 
     if has_partner? || !pensioner_disregard_applied?
       rows.except(:pensioner_capital_disregard)
@@ -226,14 +178,7 @@ class CalculationResult
   end
 
   def pensioner_disregard_rows
-    total_capital = api_response.dig(:result_summary, :capital, :total_capital_with_smod) +
-      api_response.dig(:result_summary, :partner_capital, :total_capital_with_smod)
-    disregarded = api_response.dig(:result_summary, :capital, :pensioner_disregard_applied) +
-      api_response.dig(:result_summary, :partner_capital, :pensioner_disregard_applied)
-    {
-      total_capital: monetise(total_capital),
-      pensioner_capital_disregard: monetise(-disregarded),
-    }
+    api_response.pensioner_disregard_rows.transform_values { |c| monetise(c) }
   end
 
   def main_home_assessed_equity
@@ -260,24 +205,6 @@ private
     capital_items(key, "partner_")
   end
 
-  def capital_items(key, prefix = "")
-    api_response.dig(:assessment, :"#{prefix}capital", :capital_items, key)
-  end
-
-  def employment_deduction(key, prefix)
-    value = api_response.dig(:result_summary, :"#{prefix}disposable_income", :employment_income, key)
-    0 - value if value.present?
-  end
-
-  def disposable_income_value(key, prefix)
-    api_response.dig(:assessment, :"#{prefix}disposable_income",
-                     :monthly_equivalents, :all_sources, key)
-  end
-
-  def extract_other_income(key, prefix)
-    api_response.dig(:assessment, :"#{prefix}gross_income", :other_income, :monthly_equivalents, :all_sources, key)
-  end
-
   def monetise(number, precision: 2)
     return I18n.t("generic.not_applicable") if number.nil? || number == CFE_MAX_VALUE
 
@@ -285,32 +212,22 @@ private
   end
 
   def income_rows(prefix:)
-    data = {
-      employment_income: api_response.dig(:result_summary, :"#{prefix}disposable_income", :employment_income, :gross_income),
-      benefits: api_response.dig(:assessment, :"#{prefix}gross_income", :state_benefits, :monthly_equivalents, :all_sources),
-      friends_and_family: extract_other_income(:friends_or_family, prefix),
-      maintenance: extract_other_income(:maintenance_in, prefix),
-      property_or_lodger: extract_other_income(:property_or_lodger, prefix),
-      pension: extract_other_income(:pension, prefix),
-      student_finance: api_response.dig(:assessment, :"#{prefix}gross_income", :irregular_income, :monthly_equivalents, :student_loan),
-      other: api_response.dig(:assessment, :"#{prefix}gross_income", :irregular_income, :monthly_equivalents, :unspecified_source),
-    }
-    data.transform_values { |v| monetise(v) }
+    api_response.raw_income_rows(prefix:).transform_values { |v| monetise(v) }
   end
 
   def outgoing_rows(prefix:)
     data = {
-      childcare_payments: disposable_income_value(:child_care, prefix),
-      maintenance_out: disposable_income_value(:maintenance_out, prefix),
-      legal_aid: disposable_income_value(:legal_aid, prefix),
-      income_tax: employment_deduction(:tax, prefix),
-      national_insurance: employment_deduction(:national_insurance, prefix),
-      employment_expenses: employment_deduction(:fixed_employment_deduction, prefix),
+      childcare_payments: api_response.disposable_income_value(:child_care, prefix),
+      maintenance_out: api_response.disposable_income_value(:maintenance_out, prefix),
+      legal_aid: api_response.disposable_income_value(:legal_aid, prefix),
+      income_tax: api_response.employment_deduction(:tax, prefix),
+      national_insurance: api_response.employment_deduction(:national_insurance, prefix),
+      employment_expenses: api_response.employment_deduction(:fixed_employment_deduction, prefix),
     }
 
     data.delete(:childcare_payments) unless @check.eligible_for_childcare_costs?
 
-    partner_allowance = api_response.dig(:result_summary, :"#{prefix}disposable_income", :partner_allowance)
+    partner_allowance = api_response.partner_allowance(prefix)
 
     data[:partner_allowance] = partner_allowance if partner_allowance&.positive?
 
@@ -318,12 +235,7 @@ private
   end
 
   def capital_row_items(prefix:)
-    items = {
-      property: api_response.dig(:result_summary, :"#{prefix}capital", :total_property),
-      vehicles: api_response.dig(:result_summary, :"#{prefix}capital", :total_vehicle),
-      liquid: api_response.dig(:result_summary, :"#{prefix}capital", :total_liquid),
-      non_liquid: api_response.dig(:result_summary, :"#{prefix}capital", :total_non_liquid),
-    }
+    items = api_response.capital_row_items(prefix:)
 
     level_of_help == "controlled" ? items.except(:vehicles) : items
   end

--- a/app/models/calculation_result.rb
+++ b/app/models/calculation_result.rb
@@ -6,7 +6,7 @@ class CalculationResult
 
   attr_reader :level_of_help
 
-  delegate :decision, :calculated?, :has_partner?, :ineligible?,
+  delegate :decision, :calculated?, :has_partner?, :ineligible?, :pensioner_disregard_applied?,
            :raw_capital_contribution, :raw_income_contribution,
            :smod_applied?, to: :@api_response
 
@@ -166,7 +166,7 @@ class CalculationResult
   def client_capital_subtotal_rows
     rows = api_response.client_capital_subtotal_rows.transform_values { |x| monetise(x) }
 
-    if has_partner? || !api_response.pensioner_disregard_applied?
+    if has_partner? || !pensioner_disregard_applied?
       rows.except(:pensioner_capital_disregard)
     else
       rows

--- a/app/models/cfe_result.rb
+++ b/app/models/cfe_result.rb
@@ -1,0 +1,169 @@
+class CfeResult
+  VALID_OVERALL_RESULTS = %w[eligible contribution_required ineligible].freeze
+
+  def initialize api_response
+    @api_response = api_response.deep_symbolize_keys
+  end
+
+  def decision
+    @decision ||= begin
+                    # In some circumstances CFE can return other results, such as 'partially_eligible'.
+                    # We believe that those circumstances can never be reached via CCQ.
+                    # However we want to safeguard against CFE doing something unexpected.
+                    result = api_response.dig(:result_summary, :overall_result, :result)
+
+                    raise "Unhandled CFE result: #{result}" unless VALID_OVERALL_RESULTS.include?(result)
+
+                    result
+                  end
+  end
+
+  def calculated?(section)
+    api_response.dig(:result_summary, section, :proceeding_types).any? { VALID_OVERALL_RESULTS.include?(_1[:result]) }
+  end
+
+  def raw_thresholds section
+    api_response.dig(:result_summary, section, :proceeding_types, 0)
+                                 .slice(:upper_threshold, :lower_threshold)
+  end
+
+  def result_for section
+    api_response.dig(:result_summary, section, :proceeding_types, 0, :result)
+  end
+
+  def raw_total_calculated_gross_income
+    api_response.dig(:result_summary, :gross_income, :combined_total_gross_income)
+  end
+
+  def raw_capital_contribution
+    api_response.dig(:result_summary, :overall_result, :capital_contribution)
+  end
+
+  def raw_income_contribution
+    api_response.dig(:result_summary, :overall_result, :income_contribution)
+  end
+
+  def raw_total_calculated_disposable_income
+    api_response.dig(:result_summary, :disposable_income, :combined_total_disposable_income)
+  end
+
+  def raw_total_calculated_capital
+    # # If the pensioner_capital_disregard is applied, it is applied by CFE in full even when the disregard is
+    # # greater than the client's total capital value. This can lead to the CFE 'assessed capital' figure
+    # # being a negative number, which is unsuitable for display to the end user.
+    # # Therefore we must correct the CFE result to display a zero if it comes back negative.
+    [api_response.dig(:result_summary, :capital, :combined_assessed_capital), 0].compact.max
+  end
+
+  def raw_income_rows(prefix:)
+    {
+      employment_income: api_response.dig(:result_summary, :"#{prefix}disposable_income", :employment_income, :gross_income),
+      benefits: api_response.dig(:assessment, :"#{prefix}gross_income", :state_benefits, :monthly_equivalents, :all_sources),
+      friends_and_family: extract_other_income(:friends_or_family, prefix),
+      maintenance: extract_other_income(:maintenance_in, prefix),
+      property_or_lodger: extract_other_income(:property_or_lodger, prefix),
+      pension: extract_other_income(:pension, prefix),
+      student_finance: api_response.dig(:assessment, :"#{prefix}gross_income", :irregular_income, :monthly_equivalents, :student_loan),
+      other: api_response.dig(:assessment, :"#{prefix}gross_income", :irregular_income, :monthly_equivalents, :unspecified_source),
+    }
+  end
+
+  def has_partner?
+    @has_partner ||= api_response.dig(:assessment, :partner_capital).present?
+  end
+
+  def raw_gross_income_upper_threshold
+    api_response.dig(:result_summary, :gross_income, :proceeding_types).map { |pt| pt.fetch(:upper_threshold) }.min
+  end
+
+  def ineligible?(section)
+    api_response.dig(:result_summary, section, :proceeding_types).all? { _1[:result] == "ineligible" }
+  end
+
+  def disposable_income_value(key, prefix)
+    api_response.dig(:assessment, :"#{prefix}disposable_income",
+                     :monthly_equivalents, :all_sources, key)
+  end
+
+  def employment_deduction(key, prefix)
+    value = api_response.dig(:result_summary, :"#{prefix}disposable_income", :employment_income, key)
+    0 - value if value.present?
+  end
+
+  def partner_allowance prefix
+    api_response.dig(:result_summary, :"#{prefix}disposable_income", :partner_allowance)
+  end
+
+  def disposable_income_result_row row
+    api_response.dig(:result_summary, :disposable_income, row)
+  end
+
+  def raw_gross_outgoings
+    api_response.dig(:result_summary, :disposable_income, :combined_total_outgoings_and_allowances)
+  end
+
+  def raw_disposable_income_upper_threshold
+    api_response.dig(:result_summary, :disposable_income, :proceeding_types).map { |pt| pt.fetch(:upper_threshold) }.min
+  end
+
+  def capital_items(key, prefix = "")
+    api_response.dig(:assessment, :"#{prefix}capital", :capital_items, key)
+  end
+
+  def capital_row_items(prefix:)
+    {
+      property: api_response.dig(:result_summary, :"#{prefix}capital", :total_property),
+      vehicles: api_response.dig(:result_summary, :"#{prefix}capital", :total_vehicle),
+      liquid: api_response.dig(:result_summary, :"#{prefix}capital", :total_liquid),
+      non_liquid: api_response.dig(:result_summary, :"#{prefix}capital", :total_non_liquid),
+    }
+  end
+
+  def client_capital_subtotal_rows
+    {
+      total_capital: api_response.dig(:result_summary, :capital, :total_capital),
+      smod_non_property_disregard: -api_response.dig(:result_summary, :capital, :disputed_non_property_disregard),
+      pensioner_capital_disregard: -api_response.dig(:result_summary, :capital, :pensioner_disregard_applied),
+    }
+  end
+
+  def pensioner_disregard_applied?
+    api_response.dig(:result_summary, :capital, :pensioner_disregard_applied).positive? ||
+      api_response.dig(:result_summary, :partner_capital, :pensioner_disregard_applied)&.positive?
+  end
+
+  def smod_applied?
+    api_response.dig(:result_summary, :capital, :subject_matter_of_dispute_disregard).positive?
+  end
+
+  def raw_capital_upper_threshold
+    api_response.dig(:result_summary, :capital, :proceeding_types).map { |pt| pt.fetch(:upper_threshold) }.min
+  end
+
+  def raw_client_assessed_capital
+    api_response.dig(:result_summary, :capital, :total_capital_with_smod)
+  end
+
+  def raw_partner_assessed_capital
+    api_response.dig(:result_summary, :partner_capital, :total_capital_with_smod)
+  end
+
+  def pensioner_disregard_rows
+    total_capital = api_response.dig(:result_summary, :capital, :total_capital_with_smod) +
+      api_response.dig(:result_summary, :partner_capital, :total_capital_with_smod)
+    disregarded = api_response.dig(:result_summary, :capital, :pensioner_disregard_applied) +
+      api_response.dig(:result_summary, :partner_capital, :pensioner_disregard_applied)
+    {
+      total_capital: total_capital,
+      pensioner_capital_disregard: -disregarded,
+    }
+  end
+
+  private
+
+  attr_reader :api_response
+
+  def extract_other_income(key, prefix)
+    api_response.dig(:assessment, :"#{prefix}gross_income", :other_income, :monthly_equivalents, :all_sources, key)
+  end
+end

--- a/app/models/cfe_result.rb
+++ b/app/models/cfe_result.rb
@@ -1,33 +1,33 @@
 class CfeResult
   VALID_OVERALL_RESULTS = %w[eligible contribution_required ineligible].freeze
 
-  def initialize api_response
+  def initialize(api_response)
     @api_response = api_response.deep_symbolize_keys
   end
 
   def decision
     @decision ||= begin
-                    # In some circumstances CFE can return other results, such as 'partially_eligible'.
-                    # We believe that those circumstances can never be reached via CCQ.
-                    # However we want to safeguard against CFE doing something unexpected.
-                    result = api_response.dig(:result_summary, :overall_result, :result)
+      # In some circumstances CFE can return other results, such as 'partially_eligible'.
+      # We believe that those circumstances can never be reached via CCQ.
+      # However we want to safeguard against CFE doing something unexpected.
+      result = api_response.dig(:result_summary, :overall_result, :result)
 
-                    raise "Unhandled CFE result: #{result}" unless VALID_OVERALL_RESULTS.include?(result)
+      raise "Unhandled CFE result: #{result}" unless VALID_OVERALL_RESULTS.include?(result)
 
-                    result
-                  end
+      result
+    end
   end
 
   def calculated?(section)
     api_response.dig(:result_summary, section, :proceeding_types).any? { VALID_OVERALL_RESULTS.include?(_1[:result]) }
   end
 
-  def raw_thresholds section
+  def raw_thresholds(section)
     api_response.dig(:result_summary, section, :proceeding_types, 0)
                                  .slice(:upper_threshold, :lower_threshold)
   end
 
-  def result_for section
+  def result_for(section)
     api_response.dig(:result_summary, section, :proceeding_types, 0, :result)
   end
 
@@ -90,11 +90,11 @@ class CfeResult
     0 - value if value.present?
   end
 
-  def partner_allowance prefix
+  def partner_allowance(prefix)
     api_response.dig(:result_summary, :"#{prefix}disposable_income", :partner_allowance)
   end
 
-  def disposable_income_result_row row
+  def disposable_income_result_row(row)
     api_response.dig(:result_summary, :disposable_income, row)
   end
 
@@ -154,12 +154,12 @@ class CfeResult
     disregarded = api_response.dig(:result_summary, :capital, :pensioner_disregard_applied) +
       api_response.dig(:result_summary, :partner_capital, :pensioner_disregard_applied)
     {
-      total_capital: total_capital,
+      total_capital:,
       pensioner_capital_disregard: -disregarded,
     }
   end
 
-  private
+private
 
   attr_reader :api_response
 


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/EL-1308

## What changed and why

Split out the 'parse and interpret Cfe result' from 'display result on results page' logic so that the CfeResult can be used (and extended) to allow early eligibility to check things like 'amount over the threshold' and 'gross_income_ineligible?' from the CfeResult without the formatting code currently in CalculationResult.

CalculationResult is currently in the models directory, looks (certainly now) more like a 'presenter' object that extracts common code to do with displaying (e.g consistent formatting for monetary values) 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
