### PR TITLE
EL-1372 Move flash logic into admin partial

### DIFF
--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -1,4 +1,3 @@
-= render "layouts/admin_login"
 .govuk-grid-column-full
   .govuk-button-group
     = button_to t("devise.sessions.google"), google_oauth_redirect_path, class: "govuk-button"

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -1,3 +1,4 @@
+= render "layouts/admin_login"
 .govuk-grid-column-full
   .govuk-button-group
     = button_to t("devise.sessions.google"), google_oauth_redirect_path, class: "govuk-button"

--- a/app/views/layouts/_admin_login.html.slim
+++ b/app/views/layouts/_admin_login.html.slim
@@ -1,0 +1,8 @@
+- flash.each do |type, msg|
+  .govuk-notification-banner role="region"
+    .govuk-notification-banner__header
+      h2.govuk-notification-banner__title = type.humanize
+    .govuk-notification-banner__content
+      p.govuk-notification-banner__heading = msg
+
+= yield

--- a/app/views/layouts/_admin_login.html.slim
+++ b/app/views/layouts/_admin_login.html.slim
@@ -4,5 +4,3 @@
       h2.govuk-notification-banner__title = type.humanize
     .govuk-notification-banner__content
       p.govuk-notification-banner__heading = msg
-
-= yield

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -52,13 +52,6 @@ html dir="ltr" lang="en-GB" class="govuk-template"
 
       main#main-content.govuk-main-wrapper role="main"
         div class="govuk-grid-row"
-          - flash.each do |type, msg|
-            .govuk-notification-banner role="region"
-              .govuk-notification-banner__header
-                h2.govuk-notification-banner__title = type.humanize
-              .govuk-notification-banner__content
-                p.govuk-notification-banner__heading = msg
-
           = yield
 
     = render partial: "layouts/feedback"

--- a/app/views/layouts/devise.html.slim
+++ b/app/views/layouts/devise.html.slim
@@ -26,6 +26,7 @@ html dir="ltr" lang="en-GB" class="govuk-template"
 
       main#main-content.govuk-main-wrapper role="main"
         div class="govuk-grid-row"
+          = render "layouts/admin_login"
           = yield
 
     = render partial: "layouts/feedback"

--- a/app/views/layouts/shared/_header.html.slim
+++ b/app/views/layouts/shared/_header.html.slim
@@ -1,0 +1,28 @@
+head
+  = render "layouts/analytics_head"
+  title
+    = yield(:page_title)
+    = " | " if content_for?(:page_title)
+    = t("service.name_for_page_title")
+
+  = csrf_meta_tags
+  = csp_meta_tag
+
+  = tag.meta name: "viewport", content: "width=device-width, initial-scale=1"
+  = tag.meta property: "og:image", content: asset_path("images/govuk-opengraph-image.png")
+  = tag.meta name: "theme-color", content: "#0b0c0c"
+  ruby:
+    index_prod = FeatureFlags.enabled?(:index_production, without_session_data: true) ? "all" : "noindex"
+  = tag.meta name: "robots", content: index_prod.to_s
+
+  - if ENV["PRIMARY_HOST"].present?
+    link[rel="canonical" href="#{"https://#{ENV['PRIMARY_HOST']}#{url_for(only_path: true)}"}"]
+
+  = favicon_link_tag asset_path("images/favicon.ico"), rel: "icon", sizes: "48x48"
+  = favicon_link_tag asset_path("images/favicon.svg"), rel: "icon", sizes: "any", type: "image/svg+xml"
+  = favicon_link_tag asset_path("images/govuk-icon-mask.svg"), rel: "mask-icon", color: "#0b0c0c"
+  = favicon_link_tag asset_path("images/govuk-icon-180.png"), rel: "apple-touch-icon"
+  link rel="manifest" href=asset_path("manifest.json")
+
+  = stylesheet_link_tag "application", "data-turbo-track": "reload"
+  = javascript_include_tag "application", "data-turbo-track": "reload", defer: true, nonce: true, type: "module"

--- a/app/views/start/index.html.slim
+++ b/app/views/start/index.html.slim
@@ -1,5 +1,6 @@
 .govuk-grid-column-two-thirds
   = render "shared/heading"
+  = render "layouts/admin_login"
   = render "banners"
 
   h1.govuk-heading-xl = t("service.name")


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1308)

## What changed and why

Small refactor of where the flash notice is displayed. Previously it was in application.html.slim but if we use it for the EE feature, we need better control of where it displays. Currently it is only used in the admin stuff (I think) so this refactor moves this code to a specific partial for that, which is only rendered by a new layout devise.html.slim (which is rendered for the authentication flows only).

The HTML head section is moved to a new partial to prevent duplication between the 2 layouts

## Guidance to review


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
