### PR TITLE
EL-1377 dont try to send income or outgoings forms if they are invalid

### DIFF
--- a/app/services/cfe/regular_transactions_payload_service.rb
+++ b/app/services/cfe/regular_transactions_payload_service.rb
@@ -7,8 +7,8 @@ module Cfe
         relevant_form?(:housing_costs) ||
         relevant_form?(:benefit_details)
 
-      outgoings_form = instantiate_form(OutgoingsForm)
-      income_form = instantiate_form(OtherIncomeForm)
+      outgoings_form = instantiate_form(OutgoingsForm) if relevant_form? :outgoings
+      income_form = instantiate_form(OtherIncomeForm) if relevant_form? :other_income
       benefit_details_form = instantiate_form(BenefitDetailsForm) if relevant_form?(:benefit_details)
       housing_form = if relevant_form?(:mortgage_or_loan_payment)
                        instantiate_form(MortgageOrLoanPaymentForm)

--- a/app/services/cfe_param_builders/regular_transactions.rb
+++ b/app/services/cfe_param_builders/regular_transactions.rb
@@ -36,6 +36,8 @@ module CfeParamBuilders
     }.freeze
 
     def self.build_payments(cfe_translations, form, operation)
+      return [] if form.nil?
+
       cfe_translations.select { |_cfe_name, local_name| value(form, local_name).to_i.positive? }
                       .map do |cfe_name, local_name|
         {

--- a/spec/services/cfe/regular_transactions_payload_service_spec.rb
+++ b/spec/services/cfe/regular_transactions_payload_service_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Cfe::RegularTransactionsPayloadService do
           "housing_benefit_frequency" => "monthly",
         }
       end
-      let(:relevant_steps) { %i[outgoings partner_outgoings housing_costs] }
+      let(:relevant_steps) { %i[outgoings partner_outgoings housing_costs other_income] }
 
       it "populates the payload with content from the housing costs screen" do
         service.call(session_data, payload, relevant_steps)


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/EL-1377

Don't send income or outgoings forms to CFE if their contents is invalid

## Guidance to review

We had a crash on production due to trying to send an invalid outgoings form - https://ministryofjustice.sentry.io/issues/4999162546/?project=4504177640275968&query=&referrer=project-issue-stream.

It would seem sensible to add guards to prevent this scenario for occurring, hence this change - although its not exactly clear what the user did to cause this error 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
