### PR TITLE
loosen ECR orb specification to cope with bug fixes and upgrades

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ references:
 
 orbs:
   aws-cli: circleci/aws-cli@4.1.2
-  aws-ecr: circleci/aws-ecr@9.0.1
+  aws-ecr: circleci/aws-ecr@9.0
   jira: circleci/jira@2.1.0
   slack: circleci/slack@4.5.2
 


### PR DESCRIPTION
No ticket

## What changed and why

Needed to alter AWS ERB orb version, as the version we were using no longer exists after circle upgraded it. I have loosened the version specification to prevent this issue recurring

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
