### PR TITLE
EL-1352 follow-up - remove left-over testing artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
   test-executor:
     resource_class: small
     docker:
-      - image: checkclientqualifiesdocker/circleci-image:$CIRCLE_BRANCH
+      - image: checkclientqualifiesdocker/circleci-image:main
         auth:
           username: $DOCKERHUB_USER_CCQ
           password: $DOCKERHUB_PAT_CCQ

--- a/.github/workflows/browser_tools_docker_image.yml
+++ b/.github/workflows/browser_tools_docker_image.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - EL-1352-debian-slim-image-puppeteer
 
 jobs:
   build-push:


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1352

## What changed and why

After merging EL-1352, we needed to remove the branch-specific code around the image used in the pipeline. This makes non-main builds work again


## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
