### PR TITLE
EL-1540 use default values for feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,21 +149,23 @@ or
 
 ### Feature flags
 
-For "static" feature flags we set the flag values in env vars.
+There are 2 types of FeatureFlags used by the CCQ service, Static and Time-Dependent.
+
+For "static" feature flags we set the flag values in env_vars using `.env` locally, or the `deploy/helm/values/<ENV>.yaml`for deployments to kubernetes.
 To add a new feature flag, set a `"#{flag_name.upcase}_FEATURE_FLAG"` env var with value `"ENABLED"` in all environments where you want the flag enabled.
 Then add `flag_name` to the list of flags  in `app/lib/feature_flags.rb`.
 
 When adding a `flag_name` to the list of static flags, you will need to decide if this is a `"global"` flag i.e. always taken from the env var and not the session, or a `"session"` flag i.e. taken from the `session_data` of the check.
 
-We introduced this as a way of making our feature flags 'backwards compatible' - if a user check is underway during the switch-on of a flag, their user journey will not be affected by any flag-related changes. This is because we use their `session_data` to determine the value of the flag that was set at the start of their check. 
+We introduced this as a way of making our feature flags 'backwards compatible' - if a user check is underway during the switch-on of a flag, their user journey will not be affected by any flag-related changes. This is because we use their `session_data` to determine the value of the flag that was set at the start of their check, if a specific flag was not available at that point we will use the default setting for that flag.
 
 To use the feature flag in your code, call `FeatureFlags.enabled?(:flag_name, session_data)`. For cases where you are not able to pass in `session_data` e.g. on the start page, call `FeatureFlags.enabled?(:flag_name, without_session_data: true)`.
 
 In tests, you can temporarily enable a feature flag by setting the ENV value.
 However, flags are _not_ reset between specs, so to avoid polluting other tests use an `around` block and change the ENV value back once the test has run.
 
-We also have time-dependent flags, defined in `app/lib/feature_flags.rb`, which default to disabled but also have a date associated.
-They will be enabled _on_ the associated date.
+We also have "time-dependent" flags, defined in `app/lib/feature_flags.rb`, which default to disabled but also have a date associated.
+They will be enabled _on_ the associated date. These flags also have a `public:` attribute which should always be `true` unless the flag is intended for use in tests only.
 
 When the `FEATURE_FLAG_OVERRIDES` env var is set to `enabled`, it is possible to use the `/feature-flags` endpoint to set database values that override
 env values for both static and time-based feature flags. The username is "flags" and the password is a secret stored alongside our other secrets in K8s.

--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -1,19 +1,24 @@
 class FeatureFlags
+  # public: false is a marker that this is a test flag
+  # all flags intended to go into production should have public: set to true
   ENABLED_AFTER_DATE = {
     example_2125_flag: { from: "2125-01-01", public: false },
-    mtr_accelerated: { from: "2024-06-24", public: false },
+    mtr_accelerated: { from: "2024-06-24", public: true },
   }.freeze
 
   # the values of some feature flags will come from the session and not the env variables.
   # "global" - feature flag value should be derived from the env variable
   # "session" - feature flag value should be derived from the session_data of the check
   STATIC_FLAGS = {
+    # example and example2 are just here for tests and should not be used in code.
     example: { type: "session", default: false },
+    example2: { type: "session", default: true },
     sentry: { type: "global", default: false },
     index_production: { type: "global", default: false },
     maintenance_mode: { type: "global", default: false },
     basic_authentication: { type: "global", default: false },
     early_eligibility: { type: "session", default: false },
+    legacy_assets_no_reveal: { type: "session", default: false },
   }.freeze
 
   class << self
@@ -22,19 +27,24 @@ class FeatureFlags
         raise "Pass in session_data or set without_session_data to true"
       end
 
+      #  if the flag exists in the session_data use that setting
       if session_data && session_data["feature_flags"]&.key?(flag.to_s)
         return session_data["feature_flags"][flag.to_s]
       end
 
-      if overrideable?
-        override = FeatureFlagOverride.find_by(key: flag)
-        if override
-          return override.value
-        end
-      end
+      possible_override = overrideable_flag(flag)
+      return possible_override unless possible_override.nil?
 
       if STATIC_FLAGS.key?(flag)
-        ENV["#{flag.to_s.upcase}_FEATURE_FLAG"]&.casecmp("enabled")&.zero? || STATIC_FLAGS.fetch(flag).fetch(:default)
+        # if the flag is a valid flag and of type `session` but does not
+        # exist in the session_data we return the default value for that flag
+        if STATIC_FLAGS[flag][:type] == "session"
+          STATIC_FLAGS[flag][:default]
+        else
+          # if it is a global flag we check the env_var
+          # if there is no env_var specified we use the default value for that flag
+          env_var_flag_or_default(flag)
+        end
       elsif ENABLED_AFTER_DATE.key?(flag)
         Time.current.beginning_of_day >= ENABLED_AFTER_DATE.dig(flag, :from)
       else
@@ -51,12 +61,44 @@ class FeatureFlags
     end
 
     def overrideable?
-      ENV["FEATURE_FLAG_OVERRIDES"]&.casecmp("enabled")&.zero?
+      feature_flag_override = ENV["FEATURE_FLAG_OVERRIDES"]&.downcase
+
+      if feature_flag_override.present?
+        feature_flag_override == "enabled"
+      end
     end
 
     def session_flags
-      STATIC_FLAGS.select { |_, v| v.fetch(:type) == "session" }.each_with_object({}) do |flag, flags|
-        flags[flag.first.to_s] = enabled?(flag.first, without_session_data: true)
+      # this method sets the feature flags at the start of the check
+      session_flag_keys = STATIC_FLAGS.select { |_, v| v.fetch(:type) == "session" }.keys
+
+      hash = session_flag_keys.map do |flag|
+        value = overrideable_flag(flag)
+        value = env_var_flag_or_default(flag) if value.nil?
+
+        [flag, value]
+      end
+      hash.to_h.stringify_keys
+    end
+
+  private
+
+    def overrideable_flag(flag)
+      if overrideable?
+        override = FeatureFlagOverride.find_by(key: flag)
+        if override
+          override.value
+        end
+      end
+    end
+
+    def env_var_flag_or_default(flag)
+      flag_value = ENV["#{flag.to_s.upcase}_FEATURE_FLAG"]&.downcase
+
+      if flag_value.present?
+        flag_value == "enabled"
+      else
+        STATIC_FLAGS.fetch(flag).fetch(:default)
       end
     end
   end

--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -9,6 +9,7 @@ class FeatureFlags
   # the values of some feature flags will come from the session and not the env variables.
   # "global" - feature flag value should be derived from the env variable
   # "session" - feature flag value should be derived from the session_data of the check
+  # "default" - where a flag is not set this is the value the check or tests should fall back to
   STATIC_FLAGS = {
     # example and example2 are just here for tests and should not be used in code.
     example: { type: "session", default: false },

--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -19,7 +19,6 @@ class FeatureFlags
     maintenance_mode: { type: "global", default: false },
     basic_authentication: { type: "global", default: false },
     early_eligibility: { type: "session", default: false },
-    legacy_assets_no_reveal: { type: "session", default: false },
   }.freeze
 
   class << self

--- a/spec/features/feature_flags_spec.rb
+++ b/spec/features/feature_flags_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Feature flags" do
+RSpec.describe "Feature flags admin panel" do
   around do |example|
     ENV["FEATURE_FLAGS_PASSWORD"] = "password"
     example.run
@@ -33,20 +33,6 @@ RSpec.describe "Feature flags" do
     scenario "I see link to edit a feature flag" do
       visit feature_flags_path
       expect(page).to have_content "Override"
-    end
-  end
-
-  context "when setting feature flags in the session" do
-    around do |example|
-      ENV["EXAMPLE_FEATURE_FLAG"] = "enabled"
-      example.run
-      ENV["EXAMPLE_FEATURE_FLAG"] = "disabled"
-    end
-
-    scenario "I have session feature flags set in the session" do
-      visit "new-check"
-      expect(session_contents["feature_flags"]).to include({ "example" => true })
-      expect(session_contents["feature_flags"]).not_to include({ "sentry" => false })
     end
   end
 end


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1540)

When a check is created without a particular session feature flag we now use the default for that flag.
Moved some methods out of the enabled? method as the session_flags method was also using `enabled?` but didnt need all of the functionality. So 'overrideable_flag' and 'env_var_flag' were extracted to be used by both `session_flags` and `enabled?`
This allows us to revert to using the ENV_VAR to set the sessions flags at the start of the check, and also in the tests where we turn the flags on and off around specific tests. Elsewhere it will use the default for the flag.

<!-- fill this in -->

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
