### PR TITLE
Use AlphaNumeric.alpha rather than String.random

### DIFF
--- a/spec/features/provider_authentication_spec.rb
+++ b/spec/features/provider_authentication_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Provider authentication" do
 
   context "with an existing record" do
     before do
-      create(:provider, email: mock_auth.info.fetch("email"), first_office_code: Faker::String.random)
+      create(:provider, email: mock_auth.info.fetch("email"), first_office_code: Faker::Alphanumeric.alpha)
     end
 
     scenario "callback" do


### PR DESCRIPTION
No Ticket

## What changed and why

The ProviderAuth spec fails 1/256 times due to using String.random which can generate null bytes which our DB doesn't like. Change it to AlphaNumeric.alpha so that random failures stop happening

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
