### PR TITLE
EL-1693 exclude Rails and puppeteer from combined dependency lists

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
       combined-dependencies:
         patterns:
           - "*"
+        exclude-patterns:
+          - "rails*"
   - package-ecosystem: "terraform"
     directory: "/terraform"
     schedule:
@@ -37,3 +39,5 @@ updates:
       combined-dependencies:
         patterns:
           - "*"
+        exclude-patterns:
+          - "puppeteer"


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1693)

## What changed and why

Remove Rails and puppeteer from dependabot combined dependency lists. These create unmergeable PRs which block other more important (e.g. security) related PRs

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
