### PR TITLE
EL-1640 Removing delete pvc command. Not required

### DIFF
--- a/.github/actions/delete-uat-release/action.yml
+++ b/.github/actions/delete-uat-release/action.yml
@@ -83,7 +83,6 @@ runs:
         if [[ ! -z "$found" ]]
         then
           helm delete $release_name
-          kubectl delete pvc data-$release_name-postgresql-0
           echo "message=\"Deleted UAT release ${release_name}\"" >> $GITHUB_OUTPUT
         else
           echo "message=\"UAT release, ${release_name}, not found\"" >> $GITHUB_OUTPUT


### PR DESCRIPTION
-[El-1640](https://dsdmoj.atlassian.net/browse/EL-1640)

## What changed and why

Removing delete command for PVC. No longer needed as we now use Helm Deploy. Will remove errors after every PR merge going forward.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
