### PR TITLE
EL-1633: Remove text from Partner Other property details page

### DIFF
--- a/app/views/question_flow/_additional_property_section.html.slim
+++ b/app/views/question_flow/_additional_property_section.html.slim
@@ -59,7 +59,7 @@
             field_name: "percentage_owned",
             counter:,
             label: t("question_flow.#{i18n_key}.percentage_owned.input"),
-            hint: (t("question_flow.additional_property_details.percentage_owned.hint") if @check.partner && !partner),
+            hint: t("question_flow.#{i18n_key}.percentage_owned.hint"),
             value: model.percentage_owned,
             label_size: "m"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1594,6 +1594,7 @@ en:
         input_hint: Check the statement from the mortgage provider or lender and include any other loans secured against the property
       percentage_owned:
         input: What percentage share does the partner own?
+        hint: ""
     vehicles_details:
       heading: Tell us about the vehicle
       vehicle: Vehicle


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1633)

## What changed and why

- display hint text based on `#{i18n_key}`
- partner `#{i18n_key}` hint text key value is blank

## Guidance to review

- n/a

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
