### PR TITLE
EL-1624: update `delete_uat_release.yml` GitHub action

### DIFF
--- a/.github/workflows/delete_uat_release.yml
+++ b/.github/workflows/delete_uat_release.yml
@@ -1,15 +1,12 @@
 name: Delete UAT release
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
 
 jobs:
   delete_uat_job:
-    # Adding a condition so that the `pull_request` workflow cathes merged PRs, if not caught when the PR closes. Have had some instances when the job runs but the UAT pod still exists.
-    # As per this documentation https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
-    if: github.event.pull_request.merged == true || github.event.pull_request.merged == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1624)

## What changed and why

- update `delete_uat_release.yml` to use `pull_request_target` event for GitHub action

## Guidance to review

- `pull_request_target` will trigger on PR that are closed when they have merge conflicts

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
