### PR TITLE
EL-1730 Add Feature Flag for CW Form Updates

### DIFF
--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -15,6 +15,7 @@ class FeatureFlags
     # This should go back to being a time-based feature flag once the SI date has been re-set
     # after the election on 4th July 2024
     mtr_accelerated: { type: "global", default: false },
+    cw_form_updates: { type: "global", default: false },
     shared_ownership: { type: "session", default: false },
   }.freeze
 

--- a/helm_deploy/laa-estimate-eligibility/templates/_envs.tpl
+++ b/helm_deploy/laa-estimate-eligibility/templates/_envs.tpl
@@ -69,6 +69,8 @@ env:
     value: {{ .Values.featureFlags.basicAuthentication }}
   - name: OUTGOINGS_FLOW_FEATURE_FLAG
     value: {{ .Values.featureFlags.outgoingsFlow }}
+  - name: CW_FORM_UPDATE_FEATURE_FLAG
+    value: {{ .Values.featureFlags.cwFormUpdates }}
   - name: SHARED_OWNERSHIP_FEATURE_FLAG
     value: {{ .Values.featureFlags.sharedOwnership }}
   - name: FEATURE_FLAG_OVERRIDES

--- a/helm_deploy/laa-estimate-eligibility/values/ccq-production.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/ccq-production.yaml
@@ -60,6 +60,7 @@ featureFlags:
   basicAuthentication: NOT_ENABLED
   outgoingsFlow: ENABLED
   conditionalReveals: ENABLED
+  cwFormUpdates: NOT_ENABLED
   sharedOwnership: NOT_ENABLED
 
 geckoboard:

--- a/helm_deploy/laa-estimate-eligibility/values/ccq-staging.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/ccq-staging.yaml
@@ -60,6 +60,7 @@ featureFlags:
   basicAuthentication: ENABLED
   outgoingsFlow: ENABLED
   conditionalReveals: ENABLED
+  cwFormUpdates: NOT_ENABLED
   sharedOwnership: NOT_ENABLED
 
 geckoboard:

--- a/helm_deploy/laa-estimate-eligibility/values/ccq-uat.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/ccq-uat.yaml
@@ -65,7 +65,7 @@ featureFlags:
   basicAuthentication: ENABLED
   outgoingsFlow: ENABLED
   conditionalReveals: ENABLED
-  cwFormUpdates: NOT_ENABLED
+  cwFormUpdates: ENABLED
   sharedOwnership: ENABLED
 
 postgresql:

--- a/helm_deploy/laa-estimate-eligibility/values/ccq-uat.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/ccq-uat.yaml
@@ -65,6 +65,7 @@ featureFlags:
   basicAuthentication: ENABLED
   outgoingsFlow: ENABLED
   conditionalReveals: ENABLED
+  cwFormUpdates: NOT_ENABLED
   sharedOwnership: ENABLED
 
 postgresql:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -140,6 +140,12 @@ RSpec.configure do |config|
     ENV["BASIC_AUTHENTICATION_FEATURE_FLAG"] = "disabled"
   end
 
+  config.around(:each, :cw_form_updates) do |example|
+    ENV["CW_FORM_UPDATE_FEATURE_FLAG"] = "enabled"
+    example.run
+    ENV["CW_FORM_UPDATE_FEATURE_FLAG"] = "disabled"
+  end
+
   config.around(:each, :shared_ownership) do |example|
     ENV["SHARED_OWNERSHIP_FEATURE_FLAG"] = "enabled"
     example.run


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1730)

## What changed and why

Added a global feature flag for the updated CW forms. The ticket does not specify session or global, and I think when we release this we want everyone to use the new form regardless of when the session was started. This will not break anything as the data will exist in the session for the new inputs on the forms and if the data does not exist then we handle that in the forms themselves anyway.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
