### PR TITLE
EL-1726 Bugfix Gajira GH action

### DIFF
--- a/.github/workflows/gajira.yml
+++ b/.github/workflows/gajira.yml
@@ -8,7 +8,8 @@ jobs:
   gajira:
     name: Raise Jira Issue
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.pull_request.labels, 'dependencies') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') }}
+
     steps:
     - name: Login
       uses: atlassian/gajira-login@master


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1726)

## What changed and why

according to this:
https://stackoverflow.com/questions/71481086/is-pull-request-label-available-to-a-github-action
We can get the labels into an array and compare them to trigger the job

As dependabot also adds more than 1 label this should allow us to cater for occassions where there are multiple labels too

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
