### PR TITLE
EL-1743 add qualifiers to dependabot to ignore major updates from grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
           - "*"
         exclude-patterns:
           - "rails*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "terraform"
     directory: "/terraform"
     schedule:
@@ -23,6 +26,9 @@ updates:
       combined-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -31,6 +37,9 @@ updates:
       combined-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -41,3 +50,6 @@ updates:
           - "*"
         exclude-patterns:
           - "puppeteer"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1743)

## What changed and why

Added commands to only include minor and patch upgrades in the grouping of updates

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
