### PR TITLE
EL-1833 EE data migraton 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ references:
       name: Database Setup
       command: |
         bundle exec rake db:create db:schema:load
-        bundle exec rake db:migrate
+        bundle exec rake db:migrate:with_data
 
   setup_parallel_database: &setup_parallel_database
     run:
@@ -323,14 +323,14 @@ workflows:
 # again in the future, the requires production_deploy_approval
 # in Deploy to Production is also commented out
 
-#      - production_deploy_approval:
-#          type: approval
-#          requires:
-#            - Deploy to Staging
-#          filters:
-#            branches:
-#              only:
-#                - main
+      - production_deploy_approval:
+          type: approval
+          requires:
+            - Deploy to Staging
+          filters:
+            branches:
+              only:
+                - main
       - deploy:
           name: Deploy to Production
           environment: ccq-production
@@ -341,7 +341,7 @@ workflows:
             - linters
             - build_and_push
             - Deploy to Staging
-#            - production_deploy_approval
+            - production_deploy_approval
           post-steps:
             - jira/notify:
                 job_type: deployment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,6 +307,7 @@ workflows:
             - linters
             - build_and_push
             - Deploy to UAT
+            - staging_deploy_approval
           post-steps:
             - jira/notify:
                 job_type: deployment
@@ -322,6 +323,14 @@ workflows:
 # Keeping this step commented out because we will need
 # again in the future, the requires production_deploy_approval
 # in Deploy to Production is also commented out
+      - staging_deploy_approval:
+          type: approval
+          requires:
+            - Deploy to UAT
+          filters:
+            branches:
+              only:
+                - main
 
       - production_deploy_approval:
           type: approval

--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,8 @@ gem "omniauth-google-oauth2"
 gem "omniauth-rails_csrf_protection", ">= 1.0.2"
 gem "omniauth-saml", "~> 2.2.1"
 
+gem "data_migrate"
+
 gem "rails_admin"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,9 @@ GEM
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
     csv (3.3.0)
+    data_migrate (11.1.0)
+      activerecord (>= 6.1)
+      railties (>= 6.1)
     database_cleaner-active_record (2.2.0)
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
@@ -577,6 +580,7 @@ DEPENDENCIES
   capybara
   capybara-selenium
   cssbundling-rails
+  data_migrate
   database_cleaner-active_record
   debug
   devise

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Create the development and test databases and run migrations
 
 ```
 bundle exec rails db:create
-bundle exec rails db:migrate
-bundle exec rails db:migrate RAILS_ENV=test
+bundle exec rails db:migrate:with_data
+bundle exec rails db:migrate:with_data RAILS_ENV=test
 ```
 
 Install [Yarn](https://classic.yarnpkg.com/en/) (you can use Homebrew for this) and run the below:

--- a/db/data/20241031143616_populate_early_eligibility_result_in_completed_user_journeys.rb
+++ b/db/data/20241031143616_populate_early_eligibility_result_in_completed_user_journeys.rb
@@ -1,0 +1,9 @@
+class PopulateEarlyEligibilityResultInCompletedUserJourneys < ActiveRecord::Migration[7.2]
+  def up
+    CompletedUserJourney.find_each do |check|
+      session_data_hash = check.session || {}
+      early_eligibility_result = session_data_hash["early_eligibility_selection"] == "gross"
+      check.update_columns(early_eligibility_result:)
+    end
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,0 +1,1 @@
+DataMigrate::Data.define(version: 20241031143616)

--- a/db/migrate/20241031143129_add_early_eligibility_result_to_completed_user_journeys.rb
+++ b/db/migrate/20241031143129_add_early_eligibility_result_to_completed_user_journeys.rb
@@ -1,0 +1,5 @@
+class AddEarlyEligibilityResultToCompletedUserJourneys < ActiveRecord::Migration[7.2]
+  def change
+    add_column :completed_user_journeys, :early_eligibility_result, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_10_143225) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_31_143129) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -107,7 +107,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_10_143225) do
     t.jsonb "session"
     t.string "office_code"
     t.string "early_result_type"
+    t.boolean "early_eligibility_result"
     t.index ["assessment_id"], name: "index_completed_user_journeys_on_assessment_id", unique: true
+  end
+
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
   end
 
   create_table "feature_flag_overrides", force: :cascade do |t|

--- a/lib/tasks/jobs/migrations.rake
+++ b/lib/tasks/jobs/migrations.rake
@@ -1,11 +1,11 @@
 namespace :db do
   namespace :migrations do
-    desc "Run db:migrate and retry if 2-pods-running-this-at-once issues encountered"
+    desc "Run db:migrate:with_data and retry if 2-pods-running-this-at-once issues encountered"
     task run_with_retry: :environment do
       attempts = 0
       begin
-        Rake::Task["db:migrate"].reenable
-        Rake::Task["db:migrate"].invoke
+        Rake::Task["db:migrate:with_data"].reenable
+        Rake::Task["db:migrate:with_data"].invoke
       # If 2 pods try to run a migration at once on the same database, a ConcurrentMigrationError may be encountered.
       # If 2 pods try to do initial setup at once on the same database, a RecordNotUnique error may be encountered
       # as they both try to create the schema_migrations table. RecordNotUnique could indicate an error with the


### PR DESCRIPTION
add production deploy approval so staging can be tested before we do the migration in production

[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1833)

## What changed and why

added a new gem to handle data_migrations.
This is our first data_migration and although we don't expect to have many of these, they have a way of sneaking up on you as the db is modified. So it makes sense to add this now as you cant retrospectively move migrations.

The migration runs on my machine ;) 
I tested it on `early_eligibility_selection` does not exist, is `gross` and is `continue_check`

It will not do anything on UAT as the branch is new and will have no data. it will work on main UAT when it is merged. As such I have added 2 approval steps, one for STG and one for PROD. This way we can merge to main and then test each namespace before and after the migration.

The data_migration uses `:with_data` to do the data migrations after the migrations are run. I have added this where I think it needs to be, but this is the bit I am least confident about. So the pipeline will again be the test bed for this.

## Guidance to review


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
