### PR TITLE
EL-1853 revert feature flag to be time based and update tests

### DIFF
--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -1,6 +1,7 @@
 class FeatureFlags
   ENABLED_AFTER_DATE = {
     example_2125_flag: { from: "2125-01-01", public: false },
+    mtr_accelerated: { from: "2024-11-20", public: false },
   }.freeze
 
   # the values of some feature flags will come from the session and not the env variables.
@@ -12,9 +13,6 @@ class FeatureFlags
     index_production: { type: "global", default: false },
     maintenance_mode: { type: "global", default: false },
     basic_authentication: { type: "global", default: false },
-    # This should go back to being a time-based feature flag once the SI date has been re-set
-    # after the election on 4th July 2024
-    mtr_accelerated: { type: "global", default: false },
     cw_form_updates: { type: "global", default: false },
     shared_ownership: { type: "session", default: false },
     ee_banner: { type: "session", default: false },

--- a/spec/forms/mortgage_or_loan_payment_form_spec.rb
+++ b/spec/forms/mortgage_or_loan_payment_form_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe "mortgage_or_loan_payment", :calls_cfe_early_returns_not_ineligib
   end
 
   context "when MTR accelerated is in effect" do
-    let(:before_date) { Date.new(2023, 2, 15) }
-    let(:after_date) { Date.new(2024, 7, 15) }
+    let(:before_date) { Date.new(2024, 2, 15) }
+    let(:after_date) { Date.new(2024, 11, 20) }
 
     context "without MTR accelerated" do
       let(:content_date) { before_date }
@@ -41,7 +41,7 @@ RSpec.describe "mortgage_or_loan_payment", :calls_cfe_early_returns_not_ineligib
       end
     end
 
-    context "with MTR accelerated", :mtr_accelerated_flag do
+    context "with MTR accelerated" do
       let(:content_date) { after_date }
 
       it "shows new content" do
@@ -82,7 +82,7 @@ RSpec.describe "mortgage_or_loan_payment", :calls_cfe_early_returns_not_ineligib
         end
       end
 
-      context "with MTR accelerated", :mtr_accelerated_flag do
+      context "with MTR accelerated" do
         let(:content_date) { after_date }
 
         it "shows new content" do

--- a/spec/forms/property_entry_form_spec.rb
+++ b/spec/forms/property_entry_form_spec.rb
@@ -68,9 +68,9 @@ RSpec.describe "property_entry", :calls_cfe_early_returns_not_ineligible, type: 
     end
   end
 
-  context "when MTR accelerated is in effect" do
-    let(:before_date) { Date.new(2023, 2, 15) }
-    let(:after_date) { Date.new(2024, 7, 15) }
+  context "when MTR accelerated takes effect" do
+    let(:before_date) { Date.new(2024, 2, 15) }
+    let(:after_date) { Date.new(2024, 11, 20) }
 
     context "when single" do
       context "without MTR accelerated" do
@@ -81,7 +81,7 @@ RSpec.describe "property_entry", :calls_cfe_early_returns_not_ineligible, type: 
         end
       end
 
-      context "with MTR accelerated", :mtr_accelerated_flag do
+      context "with MTR accelerated" do
         let(:content_date) { after_date }
 
         it "shows new content" do
@@ -101,7 +101,7 @@ RSpec.describe "property_entry", :calls_cfe_early_returns_not_ineligible, type: 
         end
       end
 
-      context "with MTR accelerated", :mtr_accelerated_flag do
+      context "with MTR accelerated" do
         let(:content_date) { after_date }
 
         it "shows new content" do
@@ -124,7 +124,7 @@ RSpec.describe "property_entry", :calls_cfe_early_returns_not_ineligible, type: 
         end
       end
 
-      context "with MTR accelerated", :mtr_accelerated_flag do
+      context "with MTR accelerated" do
         let(:content_date) { after_date }
 
         it "shows new content" do

--- a/spec/forms/property_form_spec.rb
+++ b/spec/forms/property_form_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe "property", :calls_cfe_early_returns_not_ineligible, type: :featu
   end
 
   context "when MTR accelerated is in effect" do
-    let(:before_date) { Date.new(2023, 2, 15) }
-    let(:after_date) { Date.new(2024, 7, 15) }
+    let(:before_date) { Date.new(2024, 2, 15) }
+    let(:after_date) { Date.new(2024, 11, 20) }
 
     context "when single" do
       context "without MTR accelerated" do
@@ -41,7 +41,7 @@ RSpec.describe "property", :calls_cfe_early_returns_not_ineligible, type: :featu
         end
       end
 
-      context "with MTR accelerated", :mtr_accelerated_flag do
+      context "with MTR accelerated" do
         let(:content_date) { after_date }
 
         it "shows new content" do
@@ -71,7 +71,7 @@ RSpec.describe "property", :calls_cfe_early_returns_not_ineligible, type: :featu
         end
       end
 
-      context "with MTR accelerated", :mtr_accelerated_flag do
+      context "with MTR accelerated" do
         let(:content_date) { after_date }
 
         it "shows new content" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -133,12 +133,6 @@ RSpec.configure do |config|
     ENV["MAINTENANCE_MODE_FEATURE_FLAG"] = "disabled"
   end
 
-  config.around(:each, :mtr_accelerated_flag) do |example|
-    ENV["MTR_ACCELERATED_FEATURE_FLAG"] = "enabled"
-    example.run
-    ENV["MTR_ACCELERATED_FEATURE_FLAG"] = "disabled"
-  end
-
   config.around(:each, :basic_authentication_flag) do |example|
     ENV["BASIC_AUTHENTICATION_FEATURE_FLAG"] = "enabled"
     example.run


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1853)

## What changed and why

reverts the MTR feature flag to be tme based and sets it to turn on on 20th November 2024

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
