### PR TITLE
EL-1810: Track when results are saved as PDF

### DIFF
--- a/app/views/results/show.html.slim
+++ b/app/views/results/show.html.slim
@@ -43,7 +43,7 @@
     .govuk-button-group
       = link_to t(".save_as_pdf"),
             download_result_path(params[:assessment_code]),
-            target: "_blank", rel: "noopener", class: "govuk-button govuk-button--secondary"
+            target: "_blank", rel: "noopener", class: "govuk-button govuk-button--secondary", id: "save_as_pdf_controlled"
 
     h2.govuk-heading-m = t(".complete_a_cw_form")
     p.govuk-body = t(".complete_a_cw_form_paragraph#{'_under_eighteen' if @check.under_eighteen_no_means_test_required?}")
@@ -94,5 +94,5 @@
   - unless @journey_continues_on_another_page || @check.under_eighteen_no_means_test_required?
     .govuk-button-group
       = link_to t(".save_as_pdf"), download_result_path(params[:assessment_code]),
-                                    target: "_blank", rel: "noopener", class: "govuk-button"
+                                    target: "_blank", rel: "noopener", class: "govuk-button", id: "save_as_pdf_certificated"
       = link_to t(".start_another_check"), new_check_path, class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" }


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-1810)

## What changed and why

- add button id for GA4

## Guidance to review

- will need to test this UAT link in Google Tag Manager "Preview" 
- Tags & triggers have been made in Google Analytics
<img width="924" alt="Screenshot 2024-11-29 at 15 50 14" src="https://github.com/user-attachments/assets/b3ece932-6009-43dc-89d4-8a3467cb1438">
<img width="932" alt="Screenshot 2024-11-29 at 15 50 24" src="https://github.com/user-attachments/assets/863ff403-ba1f-4777-8713-ef7ce80076f3">

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
