### PR TITLE
Remove production hold to deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,14 +323,14 @@ workflows:
 # again in the future, the requires production_deploy_approval
 # in Deploy to Production is also commented out
 
-      - production_deploy_approval:
-           type: approval
-           requires:
-             - Deploy to Staging
-           filters:
-             branches:
-               only:
-                 - main
+      # - production_deploy_approval:
+      #      type: approval
+      #      requires:
+      #        - Deploy to Staging
+      #      filters:
+      #        branches:
+      #          only:
+      #            - main
       - deploy:
           name: Deploy to Production
           environment: ccq-production
@@ -341,7 +341,7 @@ workflows:
             - linters
             - build_and_push
             - Deploy to Staging
-            - production_deploy_approval
+            # - production_deploy_approval
           post-steps:
             - jira/notify:
                 job_type: deployment


### PR DESCRIPTION
## What changed and why

- Reversing https://github.com/ministryofjustice/laa-check-client-qualifies/pull/1708 , as we are now into the new year.

## Guidance to review

- n/a

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
