### PR TITLE
EL-2007: Fix the Github Action to delete UAT deployments

### DIFF
--- a/.github/actions/delete-uat-release/action.yml
+++ b/.github/actions/delete-uat-release/action.yml
@@ -38,12 +38,7 @@ runs:
       run: |
         if [ $BRANCH_NAME == "not_given" ]
         then
-          if [ $GITHUB_EVENT_NAME == "pull_request" ]
-          then
-            branch=$GITHUB_HEAD_REF
-          else
-            branch=${GITHUB_REF#refs/heads/}
-          fi
+          branch=$GITHUB_HEAD_REF
         else
           branch=$BRANCH_NAME
         fi


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-2007)

## What changed and why

- This is the hypothesis of why we've made the change, based on Google Gemini: when the event is not a pull request (e.g. a push directly to a branch), it uses `${GITHUB_REF#refs/heads/}` to extract the branch name. However, if the `GITHUB_REF` environment variable is set to refs/heads/main (as it would be for a push to main), this expression correctly evaluates to main. But, if the action is triggered on a merge to main branch using a pull request using `/delete_uat_release.yml` workflow as it is setup to run on pull_request_target for closed pull requests, then the value of `GITHUB_REF` is set to `refs/pull/<PR number>/merge`, and `${GITHUB_REF#refs/heads/}` evaluates to `refs/pull/<PR number>/merge`, which is incorrect. And then the extract release name step truncates this string, eventually leaving just 'main'.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
