### PR TITLE
el-2106: make error links on partner employment income page link corr…

### DIFF
--- a/app/views/question_flow/_income_section.html.slim
+++ b/app/views/question_flow/_income_section.html.slim
@@ -13,7 +13,7 @@
            model_name: "income_model",
            field_name: "income_type",
            options: model.income_type_options,
-           form_name: "income_form",
+           form_name: (partner ? "partner_income_form" : "income_form"),
            counter:,
            value: model.income_type,
            legend_size: "m"
@@ -24,7 +24,7 @@
            model_name: "income_model",
            field_name: "income_frequency",
            options: model.income_frequency_options,
-           form_name: "income_form",
+           form_name: (partner ? "partner_income_form" : "income_form"),
            counter:,
            value: model.income_frequency,
            legend_size: "m",
@@ -32,7 +32,7 @@
 
   = render "shared/add_another/money_field",
            errors: model.errors.messages[:gross_income],
-           form_name: "income_form",
+           form_name: (partner ? "partner_income_form" : "income_form"),
            model_name: "income_model",
            field_name: "gross_income",
            counter:,
@@ -58,7 +58,7 @@
 
   = render "shared/add_another/money_field",
            errors: model.errors.messages[:income_tax],
-           form_name: "income_form",
+           form_name: (partner ? "partner_income_form" : "income_form"),
            model_name: "income_model",
            field_name: "income_tax",
            counter:,
@@ -68,7 +68,7 @@
 
   = render "shared/add_another/money_field",
            errors: model.errors.messages[:national_insurance],
-           form_name: "income_form",
+           form_name: (partner ? "partner_income_form" : "income_form"),
            model_name: "income_model",
            field_name: "national_insurance",
            counter:,

--- a/app/views/question_flow/forms/_income.html.slim
+++ b/app/views/question_flow/forms/_income.html.slim
@@ -3,7 +3,7 @@
    data-add-another-removed-feedback-text=t("question_flow.income.removed")
    data-add-another-hide-message-text=t("generic.hide_this_message")]
   .add-another-template-area data-add-another-role="template"
-    = render "income_section", i18n_key:, removeable: true, model: @form.blank_model
+    = render "income_section", i18n_key:, removeable: true, model: @form.blank_model, partner: partner
 
   = form_for(@form, url: request.path, method: :put) do |form|
     = form.govuk_error_summary t("generic.error_summary_title")
@@ -34,7 +34,7 @@
           li.govuk_text = _1
     . data-add-another-role="sectionList"
       - @form.items.each_with_index do |income, index|
-        = render "income_section", i18n_key:, removeable: index.positive?, model: income, counter: index + 1
+        = render "income_section", i18n_key:, removeable: index.positive?, model: income, counter: index + 1, partner: partner
     .govuk-button-group
       button.govuk-button.govuk-button--secondary type="button" data-add-another-role="add" = t("question_flow.income.add")
 


### PR DESCRIPTION
…ectly

[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-2106)

## What changed and why

The error links on the partner employment income page were not working because the form class was income_form and not partner_income_form.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
