### PR TITLE
el-2064: create rake task to populate satisfaction feedback pages

### DIFF
--- a/lib/tasks/populate_feedback_page.rake
+++ b/lib/tasks/populate_feedback_page.rake
@@ -1,0 +1,14 @@
+namespace :migrate do
+  desc "EL-2064: Data migration to backfill page field on Satisfaction Feedback table"
+  task populate_feedback_pages: :environment do
+    satisfaction_feedbacks = SatisfactionFeedback.where(page: nil)
+    feedbacks_count = satisfaction_feedbacks.count
+    Rails.logger.info "populate_feedback_pages: Updating #{feedbacks_count} satisfaction feedback pages"
+    satisfaction_feedbacks.find_each do |feedback|
+      page_name = feedback.level_of_help == "controlled" ? "end_of_journey_checks" : "show_results"
+      feedback.update!(page: page_name)
+    end
+    Rails.logger.info "populate_feedback_pages: #{feedbacks_count} satisfaction feedback pages updated"
+    Rails.logger.info "populate_feedback_pages: #{satisfaction_feedbacks.count} blank satisfaction feedback pages remaining"
+  end
+end

--- a/spec/lib/tasks/populate_feedback_page_spec.rb
+++ b/spec/lib/tasks/populate_feedback_page_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "migrate:populate_feedback_page", type: :task do
+  before do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  describe "migrate:populate_feedback_pages" do
+    subject(:task) { Rake::Task["migrate:populate_feedback_pages"] }
+
+    it "updates the satisfaction feedback page" do
+      controlled_satisfaction_feedback = create(:satisfaction_feedback, level_of_help: "controlled")
+      certificated_satisfaction_feedback = create(:satisfaction_feedback, level_of_help: "certificated")
+      expect(Rails.logger).to receive(:info).with("populate_feedback_pages: Updating 2 satisfaction feedback pages").once
+      expect(Rails.logger).to receive(:info).with("populate_feedback_pages: 2 satisfaction feedback pages updated").once
+      expect(Rails.logger).to receive(:info).with("populate_feedback_pages: 0 blank satisfaction feedback pages remaining").once
+      task.execute
+      expect(controlled_satisfaction_feedback.reload.page).to eq "end_of_journey_checks"
+      expect(certificated_satisfaction_feedback.reload.page).to eq "show_results"
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ unless ENV.fetch("COVERAGE", "true") == "false"
   SimpleCov.start "rails" do
     add_filter "app/mailers/exception_alert_mailer.rb"
     add_filter "app/lib/exception_notifier/templated_notifier.rb"
+    add_filter "lib/tasks/"
 
     enable_coverage :branch
 


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-2064)

## What changed and why

Update SatisfactionFeedbacks with nil page values.

On production there are 189 SatisfactionFeedbacks with page nil

I have tested this locally and in UAT, by creating 200 SatisfactionFeedback records using this script

```
100.times do
  SatisfactionFeedback.create(satisfied: "yes", level_of_help: "certificated", outcome: "eligible", comment: "This is a comment made for testing purposes. Please ignore this comment.")
end

100.times do
  SatisfactionFeedback.create(satisfied: "yes", level_of_help: "controlled", outcome: "eligible", comment: "This is a comment made for testing purposes. Please ignore this comment.")
end
```

and then runing the rake task. Both locally and in uat the rake task completed and updated the page value on all 200 records almost instantly/in less than 5 seconds.


## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
