### PR TITLE
Fix for rubocop warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
 
 inherit_gem:


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-XXX)

## What changed and why

updated rubocop.yml to fix some warnings being shown whenever rubocop was run in the terminal or on GA.
no ticket for this as the fix is so small it was easier to do it

## Guidance to review

test on main with `rubocop` then run the same on this branch to see the warnings are removed

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
