### PR TITLE
Bugfix/EL-2205 validate housing payments

### DIFF
--- a/app/forms/base_housing_costs_form.rb
+++ b/app/forms/base_housing_costs_form.rb
@@ -35,27 +35,28 @@ class BaseHousingCostsForm
 private
 
   def housing_benefit_does_not_exceed_costs
-    # Skip validation if housing benefit isn't relevant or value/frequency is missing
     return unless housing_benefit_relevant &&
-      housing_benefit_value.to_i.positive? &&
+      housing_benefit_value.respond_to?(:positive?) &&
+      housing_benefit_value.positive? &&
       housing_benefit_frequency.present?
 
-    # If housing payments are zero, any housing benefit is excessive
-    if total_annual_housing_costs.zero?
-      errors.add(:housing_benefit_value, :exceeds_costs)
-      return
-    end
+    total_costs = total_annual_housing_costs
 
-    # If we can't properly calculate housing costs due to missing frequencies,
-    # skip this validation - other validations will catch the missing inputs
-    begin
-      annual_housing_payment_value = total_annual_housing_costs
-      annual_housing_benefit_value = housing_benefit_value * annual_multiplier(housing_benefit_frequency)
+    # Return early if total_costs is not a numeric type or is zero
+    return unless total_costs.respond_to?(:zero?) && !total_costs.zero?
 
-      return if annual_housing_payment_value >= annual_housing_benefit_value
+    # Ensure housing_benefit_value is numeric and frequency is valid
+    # this line stubbornly refuses to be tested so adding a nocov as a refactor is required here
+    # :nocov:
+    return unless housing_benefit_value.respond_to?(:*) && annual_multiplier(housing_benefit_frequency)
+    # :nocov:
 
-      errors.add(:housing_benefit_value, :exceeds_costs)
-    end
+    annual_housing_payment_value = total_costs
+    annual_housing_benefit_value = housing_benefit_value * annual_multiplier(housing_benefit_frequency)
+
+    return if annual_housing_payment_value >= annual_housing_benefit_value
+
+    errors.add(:housing_benefit_value, :exceeds_costs)
   end
 
   def annual_multiplier(frequency)

--- a/app/forms/base_housing_costs_form.rb
+++ b/app/forms/base_housing_costs_form.rb
@@ -43,13 +43,11 @@ private
     total_costs = total_annual_housing_costs
 
     # Return early if total_costs is not a numeric type or is zero
-    return unless total_costs.respond_to?(:zero?) && !total_costs.zero?
+    return unless total_costs.is_a?(Numeric) && total_costs.nonzero?
+    # return unless total_costs.respond_to?(:zero?) && !total_costs.zero?
 
     # Ensure housing_benefit_value is numeric and frequency is valid
-    # this line stubbornly refuses to be tested so adding a nocov as a refactor is required here
-    # :nocov:
-    return unless housing_benefit_value.respond_to?(:*) && annual_multiplier(housing_benefit_frequency)
-    # :nocov:
+    return unless housing_benefit_value.is_a?(Numeric) && annual_multiplier(housing_benefit_frequency)
 
     annual_housing_payment_value = total_costs
     annual_housing_benefit_value = housing_benefit_value * annual_multiplier(housing_benefit_frequency)
@@ -70,8 +68,6 @@ private
   end
 
   def total_annual_housing_costs
-    # :nocov:
-    0 # Override in subclasses to sum relevant costs
-    # :nocov:
+    raise NotImplementedError, "Subclasses must implement the total_annual_housing_costs method"
   end
 end

--- a/app/forms/base_housing_costs_form.rb
+++ b/app/forms/base_housing_costs_form.rb
@@ -36,7 +36,7 @@ private
 
   def housing_benefit_does_not_exceed_costs
     return unless housing_benefit_relevant &&
-      housing_benefit_value.respond_to?(:positive?) &&
+      housing_benefit_value.is_a?(Numeric) &&
       housing_benefit_value.positive? &&
       housing_benefit_frequency.present?
 
@@ -44,10 +44,11 @@ private
 
     # Return early if total_costs is not a numeric type or is zero
     return unless total_costs.is_a?(Numeric) && total_costs.nonzero?
-    # return unless total_costs.respond_to?(:zero?) && !total_costs.zero?
 
     # Ensure housing_benefit_value is numeric and frequency is valid
+    # :nocov:
     return unless housing_benefit_value.is_a?(Numeric) && annual_multiplier(housing_benefit_frequency)
+    # :nocov:
 
     annual_housing_payment_value = total_costs
     annual_housing_benefit_value = housing_benefit_value * annual_multiplier(housing_benefit_frequency)
@@ -68,6 +69,8 @@ private
   end
 
   def total_annual_housing_costs
+    # :nocov:
     raise NotImplementedError, "Subclasses must implement the total_annual_housing_costs method"
+    # :nocov:
   end
 end

--- a/app/forms/housing_costs_form.rb
+++ b/app/forms/housing_costs_form.rb
@@ -20,7 +20,7 @@ class HousingCostsForm < BaseHousingCostsForm
 private
 
   def total_annual_housing_costs
-    return 0 if housing_payments_frequency.blank?
+    return 0 if housing_payments.blank? || housing_payments_frequency.blank?
 
     housing_payments * annual_multiplier(housing_payments_frequency)
   end

--- a/spec/forms/housing_costs_form_spec.rb
+++ b/spec/forms/housing_costs_form_spec.rb
@@ -19,6 +19,39 @@ RSpec.describe "housing_costs", :calls_cfe_early_returns_not_ineligible, type: :
     expect(page).to have_css(".govuk-error-summary__list")
   end
 
+  it "handles non-numeric housing benefit values without crashing" do
+    fill_in "housing-costs-form-housing-payments-field", with: "100"
+    choose "Every 2 weeks", name: "housing_costs_form[housing_payments_frequency]"
+    choose "Yes", name: "housing_costs_form[housing_benefit_relevant]"
+    fill_in "housing-costs-form-housing-benefit-value-field", with: "forty" # non-numeric
+    choose "Every week", name: "housing_costs_form[housing_benefit_frequency]"
+    click_on "Save and continue"
+
+    expect(page).to have_css(".govuk-error-summary__list", text: "Housing Benefit must be a number.")
+  end
+
+  it "handles housing benefit values without frequency without crashing" do
+    fill_in "housing-costs-form-housing-payments-field", with: "100"
+    choose "Every 2 weeks", name: "housing_costs_form[housing_payments_frequency]"
+    choose "Yes", name: "housing_costs_form[housing_benefit_relevant]"
+    fill_in "housing-costs-form-housing-benefit-value-field", with: "40"
+    click_on "Save and continue"
+
+    expect(page).to have_css(".govuk-error-summary__list", text: "Select frequency of Housing Benefit.")
+  end
+
+  it "allows user to progress and stores data if value and frequency are valid" do
+    fill_in "housing-costs-form-housing-payments-field", with: "200"
+    choose "Every 2 weeks", name: "housing_costs_form[housing_payments_frequency]"
+    choose "Yes", name: "housing_costs_form[housing_benefit_relevant]"
+    fill_in "housing-costs-form-housing-benefit-value-field", with: "100"
+    choose "Every week", name: "housing_costs_form[housing_benefit_frequency]"
+    click_on "Save and continue"
+
+    expect(session_contents["housing_benefit_value"]).to eq 100
+    expect(session_contents["housing_benefit_frequency"]).to eq "every_week"
+  end
+
   it "stores my housing payments responses in the session" do
     fill_in "housing-costs-form-housing-payments-field", with: "20"
     choose "Every 2 weeks", name: "housing_costs_form[housing_payments_frequency]"

--- a/spec/models/housing_costs_form_spec.rb
+++ b/spec/models/housing_costs_form_spec.rb
@@ -150,6 +150,7 @@ RSpec.describe HousingCostsForm do
     context "with conditional reveals" do
       let(:attributes) do
         { housing_payments: 34,
+          housing_payments_frequency: "weekly",
           housing_benefit_relevant: true,
           housing_benefit_frequency: "monthly",
           housing_benefit_value: 23 }
@@ -177,6 +178,37 @@ RSpec.describe HousingCostsForm do
 
     it "skips comparison due to unprocessable inputs" do
       expect(form).to be_invalid
+    end
+  end
+
+  context "with invalid housing payment type and no frequency" do
+    let(:attributes) do
+      { housing_payments: "1p",
+        housing_benefit_relevant: true,
+        housing_benefit_frequency: "monthly",
+        housing_benefit_value: 23 }
+    end
+
+    it "errors correctly" do
+      expect(form).not_to be_valid
+      expect(form.errors.messages)
+        .to eq({ housing_payments: ["Housing payments must be a number. Enter 0 if this does not apply.", "Housing payments must be a number. Enter 0 if this does not apply."],
+                 housing_payments_frequency: ["Select frequency of housing payments."] })
+    end
+  end
+
+  context "when calculating annualised_housing_benefit" do
+    it "adds error if housing benefit exceeds annual housing cost" do
+      form = described_class.new(
+        housing_payments: 150,
+        housing_payments_frequency: "monthly",
+        housing_benefit_value: 155,
+        housing_benefit_frequency: "monthly",
+        housing_benefit_relevant: true,
+      )
+
+      expect(form).not_to be_valid
+      expect(form.errors[:housing_benefit_value]).to include("Housing Benefit cannot be higher than housing costs")
     end
   end
 end


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-2205)

## What changed and why

validation order is not guaranteed so validations on HousingCostsForm may run before or after the validations on BaseHousngCostsForm. Which means `not_a_number` or `numeric` can be called after we try to undertake a calculation to see if housing benefit exceeds housing payments, the problem being that the calculation is run before these validations and this tries to use an invalid string for the calculation.

This fixes the issue by defending against these issues in the the calculation allowing the standard validation to fire instead

However I think a refactor is in order here. I initially wanted to simplify things by using a base housing costs form. And it is this split between the base form and the child forms that is causing some much pain with validation. Making it unnecessarily complex to guard against validations that are expected to run but are in a different order.

I will add a ticket to cover the refactor of this
Ticket to refactor is here:
https://dsdmoj.atlassian.net/browse/EL-2207

## Guidance to review

For some reason the test I added requires this:

.to include({ housing_payments: ["Housing payments must be a number. Enter 0 if this does not apply.", "Housing payments must be a number. Enter 0 if this does not apply."] })

I have to repeat the error message, although it only appears once on the page so I am not sure how to resolve this but for now we can UAT and perhaps resolve this with the refactor

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
