### PR TITLE
EL-2194 change answers flow for shared ownership

### DIFF
--- a/app/controllers/change_answers_controller.rb
+++ b/app/controllers/change_answers_controller.rb
@@ -19,7 +19,6 @@ class ChangeAnswersController < QuestionFlowController
         elsif next_step && step != :aggregated_means
           redirect_to helpers.check_step_path_from_step(next_step, assessment_code)
         elsif Steps::Helper.last_step_in_group?(session_data, step)
-          #  check answers thinks it is at the last step but it isnt in normal flow???!
           save_and_redirect_to_check_answers
         else
           # this is the mini-loop - it isn't the last step in the section, we have

--- a/app/controllers/change_answers_controller.rb
+++ b/app/controllers/change_answers_controller.rb
@@ -11,12 +11,15 @@ class ChangeAnswersController < QuestionFlowController
       session_data.merge!(@form.attributes_for_export_to_session)
       if FeatureFlags.enabled?(:ee_banner, session_data)
         next_step = step_with_inconsistent_data
-        if Steps::Helper.cannot_use_service?(session_data, step)
+        if Steps::Logic.landlord_is_not_the_only_joint_owner?(session_data)
+          redirect_to helpers.step_path_from_step(:cannot_use_service, assessment_code)
+        elsif Steps::Helper.cannot_use_service?(session_data, step)
           redirect_to cannot_use_service_path assessment_code:, step:
         # we need to check for aggregated_means so we know when to show the ":how_to_aggregate" screen when in a change loop
         elsif next_step && step != :aggregated_means
           redirect_to helpers.check_step_path_from_step(next_step, assessment_code)
         elsif Steps::Helper.last_step_in_group?(session_data, step)
+          #  check answers thinks it is at the last step but it isnt in normal flow???!
           save_and_redirect_to_check_answers
         else
           # this is the mini-loop - it isn't the last step in the section, we have

--- a/app/lib/steps/helper.rb
+++ b/app/lib/steps/helper.rb
@@ -51,6 +51,11 @@ module Steps
       def last_step_in_group?(session_data, step)
         step_group = step_groups_for(session_data).detect { |group| group.steps.include?(step) }
         step == step_group.steps.last
+        # step_group = step_groups_for(session_data).detect { |group| group.steps.include?(step) }
+        # is_last = step == step_group.steps.last
+        # puts "Step group for #{step}: #{step_group&.steps}"
+        # puts "Is #{step} the last step in its group? #{is_last}"
+        # is_last
       end
 
       def valid_step?(session_data, step)
@@ -100,6 +105,17 @@ module Steps
       def step_groups_for(session_data)
         all_sections.map { |section| section.grouped_steps_for(session_data) }.reduce(:+)
       end
+      # debug steps groups
+      # def step_groups_for(session_data)
+      #   grouped_steps = all_sections.map { |section|
+      #     section_steps = section.grouped_steps_for(session_data)
+      #     puts "Grouped steps for section #{section.name}: #{section_steps.map(&:steps)}"
+      #     section_steps
+      #   }.reduce(:+)
+      #
+      #   puts "Final grouped steps: #{grouped_steps.map(&:steps)}"
+      #   grouped_steps
+      # end
 
       def all_sections
         [NonFinancialSection,

--- a/app/lib/steps/outgoings_section.rb
+++ b/app/lib/steps/outgoings_section.rb
@@ -30,7 +30,13 @@ module Steps
 
       def housing_costs_group(session_data)
         steps = if session_data["property_owned"] == "shared_ownership"
-                  %i[shared_ownership_housing_costs property_entry]
+                  # the line below ensures that this test passes
+                  # spec/flows/shared_ownership_flow_spec.rb
+                  %i[shared_ownership_housing_costs]
+                  # the line below ensures that this test passes
+                  # spec/flows/change_answers_flow_spec.rb:123
+                  # %i[shared_ownership_housing_costs property_entry]
+                  # cant have both lines so how to fix this as property_entry is required across 2 sections
                 elsif Steps::Logic.owns_property_with_mortgage_or_loan?(session_data)
                   [:mortgage_or_loan_payment]
                 elsif !Steps::Logic.owns_property_outright?(session_data)

--- a/app/lib/steps/outgoings_section.rb
+++ b/app/lib/steps/outgoings_section.rb
@@ -2,7 +2,7 @@ module Steps
   class OutgoingsSection
     class << self
       def all_steps
-        %i[outgoings partner_outgoings property property_landlord cannot_use_service shared_ownership_housing_costs mortgage_or_loan_payment housing_costs]
+        %i[outgoings partner_outgoings property property_landlord cannot_use_service shared_ownership_housing_costs mortgage_or_loan_payment housing_costs property_entry]
       end
 
       def grouped_steps_for(session_data)
@@ -29,14 +29,14 @@ module Steps
       end
 
       def housing_costs_group(session_data)
-        step = if session_data["property_owned"] == "shared_ownership"
-                 :shared_ownership_housing_costs
-               elsif Steps::Logic.owns_property_with_mortgage_or_loan?(session_data)
-                 :mortgage_or_loan_payment
-               elsif !Steps::Logic.owns_property_outright?(session_data)
-                 :housing_costs
-               end
-        Steps::Group.new(step) if step
+        steps = if session_data["property_owned"] == "shared_ownership"
+                  %i[shared_ownership_housing_costs property_entry]
+                elsif Steps::Logic.owns_property_with_mortgage_or_loan?(session_data)
+                  [:mortgage_or_loan_payment]
+                elsif !Steps::Logic.owns_property_outright?(session_data)
+                  [:housing_costs]
+                end
+        Steps::Group.new(*steps) if steps
       end
     end
   end

--- a/spec/flows/change_answers_flow_spec.rb
+++ b/spec/flows/change_answers_flow_spec.rb
@@ -90,4 +90,50 @@ RSpec.describe "Change answers", :stub_cfe_calls_with_webmock, type: :feature do
     fill_in_immigration_or_asylum_screen
     confirm_screen("check_answers")
   end
+
+  context "when changing answers related to joint ownership", :ee_banner, :shared_ownership do
+    it "redirects to the exit page when the user selects 'No' after initial selection `Yes, with a mortgage or loan`" do
+      start_assessment
+      fill_in_forms_until(:property)
+      fill_in_property_screen(choice: "Yes, with a mortgage or loan")
+      fill_in_forms_until(:check_answers)
+      within "#table-property" do
+        click_on "Change"
+      end
+      fill_in_property_screen(choice: "Yes, through a shared ownership scheme")
+      fill_in_housing_shared_who_screen(choice: "No")
+      confirm_screen(:cannot_use_service)
+      expect(page).to have_content "You cannot use this service if your client joint-owns a shared ownership property with the landlord and someone else."
+    end
+
+    it "redirects to the exit page when the user selects 'No' after initial selection `Yes, owned outright`" do
+      start_assessment
+      fill_in_forms_until(:property)
+      fill_in_property_screen(choice: "Yes, owned outright")
+      fill_in_forms_until(:check_answers)
+      within "#table-property" do
+        click_on "Change"
+      end
+      fill_in_property_screen(choice: "Yes, through a shared ownership scheme")
+      fill_in_housing_shared_who_screen(choice: "No")
+      confirm_screen(:cannot_use_service)
+      expect(page).to have_content "You cannot use this service if your client joint-owns a shared ownership property with the landlord and someone else."
+    end
+
+    it "shows the home-client-lives-in page when the user changes from `Yes, owned outright` to `Yes, through a shared ownership scheme`" do
+      start_assessment
+      fill_in_forms_until(:property)
+      fill_in_property_screen(choice: "Yes, owned outright")
+      fill_in_forms_until(:check_answers)
+      within "#table-property" do
+        click_on "Change"
+      end
+      fill_in_property_screen(choice: "Yes, through a shared ownership scheme")
+      fill_in_property_landlord_screen
+      fill_in_shared_ownership_housing_costs_screen(rent: 125, mortgage: 125, housing_benefit: 120.00)
+      confirm_screen(:property_entry)
+      expect(page).to have_content "The home your client usually lives in"
+      expect(page).to have_content "How much is left to pay on the mortgage?"
+    end
+  end
 end

--- a/spec/flows/shared_ownership_flow_spec.rb
+++ b/spec/flows/shared_ownership_flow_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "shared ownership work flow", :stub_cfe_calls_with_webmock, type: :feature do
+  before do
+    start_assessment
+    fill_in_forms_until(:level_of_help)
+    fill_in_level_of_help_with(:controlled)
+  end
+
+  it "shows me an immigration or asylum screen instead of a matter type screen" do
+    start_assessment
+    fill_in_forms_until(:property)
+    fill_in_property_screen(choice: "Yes, through a shared ownership scheme")
+    fill_in_housing_shared_who_screen(choice: "Yes")
+    confirm_screen(:shared_ownership_housing_costs)
+    fill_in_shared_ownership_housing_costs_screen
+    fill_in_property_entry_screen
+    #  just gets stuck in a property_entry loop
+    confirm_screen(:additional_property)
+    fill_in_forms_until(:check_answers)
+    expect(page).to have_content "Yes, through a shared ownership scheme"
+  end
+end

--- a/spec/flows/shared_ownership_flow_spec.rb
+++ b/spec/flows/shared_ownership_flow_spec.rb
@@ -1,13 +1,7 @@
 require "rails_helper"
 
-RSpec.describe "shared ownership work flow", :stub_cfe_calls_with_webmock, type: :feature do
-  before do
-    start_assessment
-    fill_in_forms_until(:level_of_help)
-    fill_in_level_of_help_with(:controlled)
-  end
-
-  it "shows me an immigration or asylum screen instead of a matter type screen" do
+RSpec.describe "shared ownership work flow", :ee_banner, :shared_ownership, :stub_cfe_calls_with_webmock, type: :feature do
+  it "allows me to reach check answers via the shared ownership questions" do
     start_assessment
     fill_in_forms_until(:property)
     fill_in_property_screen(choice: "Yes, through a shared ownership scheme")
@@ -15,7 +9,6 @@ RSpec.describe "shared ownership work flow", :stub_cfe_calls_with_webmock, type:
     confirm_screen(:shared_ownership_housing_costs)
     fill_in_shared_ownership_housing_costs_screen
     fill_in_property_entry_screen
-    #  just gets stuck in a property_entry loop
     confirm_screen(:additional_property)
     fill_in_forms_until(:check_answers)
     expect(page).to have_content "Yes, through a shared ownership scheme"

--- a/spec/support/flow_helpers.rb
+++ b/spec/support/flow_helpers.rb
@@ -279,6 +279,23 @@ def fill_in_housing_shared_who_screen(choice: "Yes")
   click_on "Save and continue"
 end
 
+def fill_in_shared_ownership_housing_costs_screen(rent: 100, mortgage: 100, housing_benefit: 95)
+  confirm_screen :shared_ownership_housing_costs
+
+  choose "Every month", name: "shared_ownership_housing_costs_form[combined_frequency]"
+  fill_in "shared_ownership_housing_costs_form[rent]", with: rent
+  fill_in "shared_ownership_housing_costs_form[shared_ownership_mortgage]", with: mortgage
+
+  if housing_benefit.positive?
+    choose "Yes", name: "shared_ownership_housing_costs_form[housing_benefit_relevant]"
+    fill_in "shared_ownership_housing_costs_form[housing_benefit_value]", with: housing_benefit
+    choose "Every month", name: "shared_ownership_housing_costs_form[housing_benefit_frequency]"
+  else
+    choose "No", name: "shared_ownership_housing_costs_form[housing_benefit_relevant]"
+  end
+  click_on "Save and continue"
+end
+
 def fill_in_housing_costs_screen(housing_payments: 0, housing_benefit: 0)
   confirm_screen :housing_costs
 


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-2194)

## What changed and why

added in redirect on change answers when multiple parties own the property and users need to see the exit page
added in property_entry step to outgoings to account for shared-ownership in change answers flow

Issues: we have an infinite loop on property_entry, fixing this causes the change answers test of shared ownership to fail.

What is the issue?
We exit Change Answers when we reach `last_step_in_group`
`:shared_ownership_housing_costs` is the last step in the `OutgoingsSection` and `:property_entry` is the first step in PropertySection, so this works fine for the standard flow but in change answers we return to change answers without getting all required information.

Adding in a fix to send users to property_entry has so many edge cases to consider that you just end up with a complex method that may have unintended consequences elsewhere.

We have a lot of shared steps in these 2 sections:
```
  :property,
  :property_landlord,
  :cannot_use_service,
  :shared_ownership_housing_costs,
  :mortgage_or_loan_payment,
  :housing_costs,
  :property_entry
```
We may need to consider how we would refactor this to be able to complete this feature. Ideally there is a solution that we can identify that means we can refactor the service after delivery of this feature so I think that should be the first consideration

## Guidance to review
I have left in some debug steps commented out, these will be removed before merge but just in case something arises in review or UAT i want to keep these available on this branch
## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
