### PR TITLE
EL-2194 show exit page when multiple owners

### DIFF
--- a/app/controllers/change_answers_controller.rb
+++ b/app/controllers/change_answers_controller.rb
@@ -11,7 +11,9 @@ class ChangeAnswersController < QuestionFlowController
       session_data.merge!(@form.attributes_for_export_to_session)
       if FeatureFlags.enabled?(:ee_banner, session_data)
         next_step = step_with_inconsistent_data
-        if Steps::Helper.cannot_use_service?(session_data, step)
+        if Steps::Logic.landlord_is_not_the_only_joint_owner?(session_data)
+          redirect_to helpers.step_path_from_step(:cannot_use_service, assessment_code)
+        elsif Steps::Helper.cannot_use_service?(session_data, step)
           redirect_to cannot_use_service_path assessment_code:, step:
         # we need to check for aggregated_means so we know when to show the ":how_to_aggregate" screen when in a change loop
         elsif next_step && step != :aggregated_means

--- a/spec/flows/change_answers_flow_spec.rb
+++ b/spec/flows/change_answers_flow_spec.rb
@@ -90,4 +90,34 @@ RSpec.describe "Change answers", :stub_cfe_calls_with_webmock, type: :feature do
     fill_in_immigration_or_asylum_screen
     confirm_screen("check_answers")
   end
+
+  context "when changing answers related to joint ownership", :ee_banner, :shared_ownership do
+    it "redirects to the exit page when the user selects 'No' after initial selection `Yes, with a mortgage or loan`" do
+      start_assessment
+      fill_in_forms_until(:property)
+      fill_in_property_screen(choice: "Yes, with a mortgage or loan")
+      fill_in_forms_until(:check_answers)
+      within "#table-property" do
+        click_on "Change"
+      end
+      fill_in_property_screen(choice: "Yes, through a shared ownership scheme")
+      fill_in_housing_shared_who_screen(choice: "No")
+      confirm_screen(:cannot_use_service)
+      expect(page).to have_content "You cannot use this service if your client joint-owns a shared ownership property with the landlord and someone else."
+    end
+
+    it "redirects to the exit page when the user selects 'No' after initial selection `Yes, owned outright`" do
+      start_assessment
+      fill_in_forms_until(:property)
+      fill_in_property_screen(choice: "Yes, owned outright")
+      fill_in_forms_until(:check_answers)
+      within "#table-property" do
+        click_on "Change"
+      end
+      fill_in_property_screen(choice: "Yes, through a shared ownership scheme")
+      fill_in_housing_shared_who_screen(choice: "No")
+      confirm_screen(:cannot_use_service)
+      expect(page).to have_content "You cannot use this service if your client joint-owns a shared ownership property with the landlord and someone else."
+    end
+  end
 end


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-2194)

## What changed and why

Show the user the `cannot-use-service` page when there are multiple owners
add tests for the change answers flow to trigger the page

## Guidance to review

this has been taken from the original EL-2194 but just handles the exit page requirements from that ticket

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
