### PR TITLE
el-2213: add rake task to delete feedbacks

### DIFF
--- a/lib/tasks/delete_feedback.rake
+++ b/lib/tasks/delete_feedback.rake
@@ -1,0 +1,26 @@
+namespace :migrate do
+  desc "EL-2213: Delete unwanted feedback from Satisfaction Feedback table"
+  # Rake task to delete unwanted feedback.
+  # Call with "rake migrate:delete_feecback[mock, 'start_date_time', 'end_date_time']"
+  # e.g. rake "migrate:delete_feedback[false, '2025-04-24 14:26:00', '2025-04-24 14:27:00']"
+  # Running with mock=true will output the number of records to be deleted without actually deleting any
+  # (to allow for testing).
+
+  task :delete_feedback, %i[mock start_date_time end_date_time] => :environment do |_task, args|
+    if args.count != 3
+      Rails.logger.info "call with rake migrate:delete_feecback[mock, start_date_time, end_date_time]"
+      next
+    end
+
+    mock = args[:mock].to_s.downcase.strip != "false"
+    start_date_time = Time.zone.parse(args[:start_date_time])
+    end_date_time = Time.zone.parse(args[:end_date_time])
+    Rails.logger.info "delete_feedback: mock=#{mock}, start_date_time=#{start_date_time}, end_date_time=#{end_date_time}"
+    satisfaction_feedbacks = SatisfactionFeedback.where("created_at > ? and created_at < ?", start_date_time, end_date_time)
+    feedbacks_count = satisfaction_feedbacks.count
+    Rails.logger.info "delete_feedback: Deleting #{feedbacks_count} satisfaction feedbacks"
+    satisfaction_feedbacks.in_batches(&:delete_all) unless mock
+    Rails.logger.info "delete_feedback: #{feedbacks_count} satisfaction feedbacks deleted"
+    Rails.logger.info "delete_feedback: #{satisfaction_feedbacks.count} satisfaction feedbacks remaining"
+  end
+end

--- a/spec/lib/tasks/delete_feedback_spec.rb
+++ b/spec/lib/tasks/delete_feedback_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe "migrate:delete_feedback", type: :task do
+  let(:feedback_one) { create(:satisfaction_feedback) }
+  let(:feedback_two) { create(:satisfaction_feedback) }
+  let(:feedback_three) { create(:satisfaction_feedback) }
+  let(:mock) { "true" }
+  let(:start_date_time) { "2025-04-24 12:05:00" }
+  let(:end_date_time) { "2025-04-24 12:15:00" }
+
+  before do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+    Rake::Task["migrate:delete_feedback"].reenable
+    feedback_one.update!(created_at: Time.zone.local(2025, 4, 24, 12, 0, 0))
+    feedback_two.update!(created_at: Time.zone.local(2025, 4, 24, 12, 10, 0))
+    feedback_three.update!(created_at: Time.zone.local(2025, 4, 24, 12, 20, 0))
+  end
+
+  describe "migrate:delete_feedback" do
+    subject(:task) { Rake::Task["migrate:delete_feedback"] }
+
+    context "when run with mock true" do
+      it "does not delete the satisfaction feedbacks" do
+        expect(SatisfactionFeedback.count).to eq 3
+        expect(Rails.logger).to receive(:info).with("delete_feedback: mock=true, start_date_time=2025-04-24 12:05:00 UTC, end_date_time=2025-04-24 12:15:00 UTC").once
+        expect(Rails.logger).to receive(:info).with("delete_feedback: Deleting 1 satisfaction feedbacks").once
+        expect(Rails.logger).to receive(:info).with("delete_feedback: 1 satisfaction feedbacks deleted").once
+        expect(Rails.logger).to receive(:info).with("delete_feedback: 1 satisfaction feedbacks remaining").once
+        task.invoke(mock, start_date_time, end_date_time)
+        expect(SatisfactionFeedback.count).to eq 3
+      end
+    end
+
+    context "when run with mock false" do
+      let(:mock) { "false" }
+
+      it "deletes the satisfaction feedbacks" do
+        expect(SatisfactionFeedback.count).to eq 3
+        expect(Rails.logger).to receive(:info).with("delete_feedback: mock=false, start_date_time=2025-04-24 12:05:00 UTC, end_date_time=2025-04-24 12:15:00 UTC").once
+        expect(Rails.logger).to receive(:info).with("delete_feedback: Deleting 1 satisfaction feedbacks").once
+        expect(Rails.logger).to receive(:info).with("delete_feedback: 1 satisfaction feedbacks deleted").once
+        expect(Rails.logger).to receive(:info).with("delete_feedback: 0 satisfaction feedbacks remaining").once
+        task.invoke(mock, start_date_time, end_date_time)
+        expect(SatisfactionFeedback.count).to eq 2
+      end
+    end
+
+    context "when called with the wrong number of arguments" do
+      let(:mock) { "false" }
+
+      it "outputs an instruction" do
+        expect(Rails.logger).to receive(:info).with("call with rake migrate:delete_feecback[mock, start_date_time, end_date_time]").once
+        task.invoke(mock, start_date_time)
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-2213)

## What changed and why

This rake task deletes unwanted feedback from the SatisfactionFeedback table.

It can be run as follows `rake "migrate:delete_feedback[false, '2025-03-27 14:07:00', '2025-03-27 23:23:00']"`

which would delete 1470 records as specified in ticket

When run with the first argument as true the rake task outputs the number of records that would be deleted without actually deleting any records, to allow for testing.

I have tested this locally and in uat by running the following script to create 2000 satisfaction feedback records and then running the rake task to delete these records - both locally and in uat the rake task completed almost instantly (in  <5 seconds).

```
2000.times do
  SatisfactionFeedback.create(satisfied: "yes", level_of_help: "certificated", outcome: "eligible", comment: "This is a comment made for testing purposes. Please ignore this comment.")
end
```

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
