### PR TITLE
EL-2297: Change the early eligibility banner back to blue

### DIFF
--- a/app/assets/stylesheets/early-result-banner.scss
+++ b/app/assets/stylesheets/early-result-banner.scss
@@ -1,3 +1,5 @@
+@use "govuk-frontend/dist/govuk/all" as *; // This means we can use GOV.UK variables i.e. `$govuk-etc`
+
 .panel-blue {
   background: govuk-colour("blue");
   padding: 30px;


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-2297)

## What changed and why

- If applied, this lets us use `govuk-colour("blue")` as a variable in`app/assets/stylesheets/early-result-banner.scss`

## Guidance to review

- n/a

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
