### PR TITLE
el-2305: prevent ee banner being displayed for passported checks

### DIFF
--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -150,6 +150,10 @@ class Check
     Steps::Logic.non_means_tested?(session_data)
   end
 
+  def passported?
+    Steps::Logic.passported?(session_data)
+  end
+
   def skip_income_questions?
     Steps::Logic.skip_income_questions?(session_data)
   end

--- a/app/views/question_flow/_early_result_banner.html.slim
+++ b/app/views/question_flow/_early_result_banner.html.slim
@@ -1,4 +1,4 @@
-- if @check.early_ineligible_result?
+- if @check.early_ineligible_result? && !@check.passported?
   .govuk-panel.panel-blue.govuk-panel--confirmation class="govuk-!-text-align-left govuk-!-margin-bottom-9"
     .govuk-panel__body
       h2.govuk-heading-l.white_text

--- a/spec/flows/early_result_spec.rb
+++ b/spec/flows/early_result_spec.rb
@@ -89,6 +89,18 @@ RSpec.describe "Early result journey", type: :feature do
         expect(page).not_to have_content("Gross monthly income limit exceeded")
         fill_in_partner_outgoings_screen
       end
+
+      context "when I use the back button to change the passporting benefit value to Yes" do
+        it "does not display the banner on the partner details page" do
+          confirm_screen("partner_details")
+          expect(page).to have_content("Gross monthly income limit exceeded")
+          6.times { click_on "Back" }
+          confirm_screen("applicant")
+          fill_in_applicant_screen(partner: partner_value, passporting: "Yes")
+          confirm_screen("partner_details")
+          expect(page).not_to have_content("Gross monthly income limit exceeded")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-2305)

## What changed and why

Don't show ee banner if the check is for a passported client.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
