### PR TITLE
el-2368: Use eager loading for issue updates

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -18,7 +18,7 @@ class Issue < ApplicationRecord
   end
 
   def self.issues_for_updates_page
-    Issue.joins(:issue_updates).where(status: [statuses[:active], statuses[:resolved]]).uniq
+    Issue.includes(:issue_updates).where(status: [statuses[:active], statuses[:resolved]]).where.not(issue_updates: { issue_id: nil }).references(:issue_updates).uniq
   end
 
   def title_for_sentences

--- a/app/views/updates/index.html.slim
+++ b/app/views/updates/index.html.slim
@@ -1,7 +1,7 @@
 .govuk-grid-column-full
   = render "shared/heading"
   h1.govuk-heading-l = t(".updates")
-  - ChangeLog.change_logs_and_issues_for_updates_page.each do |issue_or_change_log|
+  - ChangeLog.with_rich_text_content.change_logs_and_issues_for_updates_page.each do |issue_or_change_log|
     - if issue_or_change_log.is_a?(Issue)
       = render "issue", issue: issue_or_change_log
     - else


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-2368)

## What changed and why
For discussion:
I have been unable to recreate the sentry issue in the above ticket, either locally or on uat main. I have tried using the bullet gem but that still didn't identify any n+1 query on the start/index page.

Bullet did identify an n+1 issue with our use of ActionText, however, this only affects the updates/index page (/updates). I have added a fix to app/views/updates/index.html.slim as outlined here https://guides.rubyonrails.org/action_text_overview.html#avoiding-n-1-queries to try and address this issue.

I have also made a change to app/models/issue.rb in the hope that it might resolve the Sentry alerts in the ticket, but without being able to recreate the issue I have low confidence that the fix will work. The fix is to use eager loading of issue_updates when retrieving Issue.issues_for_updates_page as outlined [here](https://medium.com/@rail_to_rescue/eager-loading-in-a-ruby-on-rails-3c6aebba49cf) 

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
