### PR TITLE
el-2409-part-1: update psql-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,11 +53,18 @@ WORKDIR /app
 
 RUN apt update
 # Need postgres for db, node for puppeteer (PDFs) and pdftk for CWForms
-RUN apt install -y postgresql-client nodejs pdftk
+RUN apt install -y nodejs pdftk
 
 # install all chromium's dependencies, but then remove chromium itself as we will be installing via puppeteer
 RUN apt install -y chromium
 RUN apt remove -y chromium
+
+# install postgreql-client-17 as it is not part of base image
+RUN apt-get update && apt-get install -y wget gnupg lsb-release ca-certificates \
+  && echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+  && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/pgdg.gpg \
+  && apt-get update && apt-get install -y postgresql-client-17 \
+  && rm -rf /var/lib/apt/lists/*
 
 # make a config directory in $HOME
 RUN mkdir -p /.config/chromium


### PR DESCRIPTION
We need to update psql-client in order to be able to run pg_dump. Currently we are getting a server version mismatch error if we try to run pg_dump on a pod. This will allow us to test pg_dump on uat-main and staging.

[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-2409)

## What changed and why

<!-- fill this in -->

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
