### PR TITLE
el-2391: remove references to early_eligibility_selection

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -14,9 +14,7 @@ class ResultsController < ApplicationController
   end
 
   def show
-    # ee_banner @early_eligibility_selection can be removed when FF is removed
     @early_result_type = session_data.dig("early_result", "type")
-    @early_eligibility_selection = session_data.fetch("early_eligibility_selection", nil)
     @model = CalculationResult.new(session_data)
 
     track_completed_journey(@model) unless @check.early_ineligible_result?
@@ -26,9 +24,7 @@ class ResultsController < ApplicationController
   end
 
   def download
-    # ee_banner @early_eligibility_selection can be removed when FF is removed
     @early_result_type = session_data.dig("early_result", "type")
-    @early_eligibility_selection = session_data.fetch("early_eligibility_selection", nil)
     track_page_view(page: :download_results)
     @model = CalculationResult.new(session_data)
     @sections = CheckAnswers::SectionListerService.call(session_data)

--- a/app/models/calculation_result.rb
+++ b/app/models/calculation_result.rb
@@ -13,7 +13,6 @@ class CalculationResult
 
   def initialize(session_data)
     @api_response = CfeResult.new session_data["api_response"]
-    @early_eligibility_selection = session_data.fetch("early_eligibility_selection", nil)
     @level_of_help = session_data.fetch("level_of_help", "certificated")
     @check = Check.new(session_data)
   end
@@ -42,11 +41,11 @@ class CalculationResult
 
     case api_response.result_for(section)
     when "ineligible"
-      Summary.new(**thresholds.merge(status: "ineligible"), ineligible_gross_income: @early_eligibility_selection)
+      Summary.new(**thresholds.merge(status: "ineligible"))
     when "contribution_required"
-      Summary.new(**thresholds.merge(status: "contribution_required_and_overall_#{decision}"), ineligible_gross_income: @early_eligibility_selection)
+      Summary.new(**thresholds.merge(status: "contribution_required_and_overall_#{decision}"))
     else
-      Summary.new(**thresholds.merge(status: "eligible"), ineligible_gross_income: @early_eligibility_selection)
+      Summary.new(**thresholds.merge(status: "eligible"))
     end
   end
 

--- a/app/views/results/_capital_table.html.slim
+++ b/app/views/results/_capital_table.html.slim
@@ -1,5 +1,4 @@
-/ ee_banner @early_eligibility_selection can be removed when FF is removed
-- if @early_eligibility_selection == "gross" || @early_result_type == "gross_income"
+- if @early_result_type == "gross_income"
      p class="govuk-body" = t(".not_assessed")
 - else
   - if @is_pdf == true

--- a/app/views/results/_outgoings_table.html.slim
+++ b/app/views/results/_outgoings_table.html.slim
@@ -1,5 +1,4 @@
-/ ee_banner @early_eligibility_selection can be removed when FF is removed
-- if @early_eligibility_selection == "gross" || @early_result_type == "gross_income"
+- if @early_result_type == "gross_income"
   p class="govuk-body" = t(".not_assessed")
 - else
   = pdf_friendly_h2(t("results.show.client_outgoings"), "m", @is_pdf)

--- a/app/views/results/_summary.html.slim
+++ b/app/views/results/_summary.html.slim
@@ -1,19 +1,13 @@
 - data = @model.summary_data(section)
 - status = data.status.dasherize
-/ ee_banner: conditionals and reference to early_result can be removed when FF is removed
-- early_result = data.ineligible_gross_income == "gross" && section != :gross_income
 
-- unless early_result
-  - total_calc = @model.send("total_calculated_without_zeros_#{section}")
+- total_calc = @model.send("total_calculated_without_zeros_#{section}")
 
-. class="summary-box summary-box-#{early_result ? "not-assessed" : status}"
+. class="summary-box summary-box-#{status}"
   p.govuk-body-l.summary-list-subheader class="govuk-!-margin-bottom-0" = t("results.show.section_summaries.heading.#{section}")
   h3.govuk-heading-l class="govuk-!-margin-bottom-2 govuk-!-margin-top-0" = total_calc
 
-  - if early_result
-    .govuk-tag
-      = t("results.show.section_summaries.not_assessed")
-  - elsif data.status == "ineligible"
+  - if data.status == "ineligible"
     .govuk-tag.govuk-tag--custom-red
       = t("results.show.section_summaries.exceeds_upper_limit_#{section}", upper_threshold: data.upper_threshold)
   - elsif data.status == "contribution_required_and_overall_contribution_required"
@@ -33,19 +27,17 @@
                     else
                       t("results.show.section_summaries.matter_types.none")
                     end
-    - if early_result
-      => t("results.show.section_summaries.texts.not_assessed_desc")
-    - else
-      - unless %w[ineligible ineligible_no_lower_threshold].include?(data.status)
-        => t("results.show.section_summaries.texts.#{section}.#{data.status}#{upper_snippet}#{lower_snippet}",
-              upper_threshold: data.upper_threshold,
-              lower_threshold: data.lower_threshold,
-              matter_type:,
-              capital_contribution: @model.capital_contribution,
-              income_contribution: @model.income_contribution)
-      - if links
-        p.govuk-body-m
-          = link_to t("results.show.section_summaries.see_calculation"),
-                    "##{data[:section]}",
-                    class: "summary-box-link",
-                    "aria-label": t("results.show.section_summaries.see_calculation_aria_label.#{data[:section]}")
+
+    - unless %w[ineligible ineligible_no_lower_threshold].include?(data.status)
+      => t("results.show.section_summaries.texts.#{section}.#{data.status}#{upper_snippet}#{lower_snippet}",
+            upper_threshold: data.upper_threshold,
+            lower_threshold: data.lower_threshold,
+            matter_type:,
+            capital_contribution: @model.capital_contribution,
+            income_contribution: @model.income_contribution)
+    - if links
+      p.govuk-body-m
+        = link_to t("results.show.section_summaries.see_calculation"),
+                  "##{data[:section]}",
+                  class: "summary-box-link",
+                  "aria-label": t("results.show.section_summaries.see_calculation_aria_label.#{data[:section]}")


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-2291)

## What changed and why

Remove references to early_eligibility_selection - these are no longer required now that the early_eligibility feature flag has been removed.

## Guidance to review

<!-- anything useful to let the reviewer know? -->

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
