### PR TITLE
EL-2268: Delete SQL attack data from AnalyticEvent table

### DIFF
--- a/lib/tasks/delete_analytics_event_via_assessment_code.rake
+++ b/lib/tasks/delete_analytics_event_via_assessment_code.rake
@@ -24,9 +24,12 @@ namespace :migrate do
     targetted_codes_from_analytics_events = AnalyticsEvent.where(assessment_code: codes_to_delete)
     analytics_count = targetted_codes_from_analytics_events.count
 
-    if analytics_count.zero?
+    unless targetted_codes_from_analytics_events.exists?
       Rails.logger.info "delete_analytics_events_based_on_assessment_code: No events AnalyticsEvent data found, with those criteria"
-    elsif mock
+      return
+    end
+
+    if mock
       Rails.logger.info "delete_analytics_events_based_on_assessment_code: #{analytics_count} AnalyticsEvent data would have been deleted"
     else
       targetted_codes_from_analytics_events.in_batches(&:delete_all)

--- a/lib/tasks/delete_analytics_event_via_assessment_code.rake
+++ b/lib/tasks/delete_analytics_event_via_assessment_code.rake
@@ -8,12 +8,12 @@ namespace :migrate do
 
   task :delete_analytics_events_based_on_assessment_code, %i[mock] => :environment do |_task, args|
     if args.count != 1
-      Rails.logger.info "call with rake migrate:delete_analytics_events[mock]"
+      Rails.logger.info 'call with rake "migrate:delete_analytics_events_based_on_assessment_code[mock]"'
       next
     end
 
     mock = args[:mock].to_s.downcase.strip != "false"
-    Rails.logger.info "delete_analytics_events: mock=#{mock}"
+    Rails.logger.info "delete_analytics_events_based_on_assessment_code: mock=#{mock}"
 
     codes_to_delete = %w[
       b5123acb-3582-4dad-9021-0eb6e0bc527f
@@ -25,13 +25,13 @@ namespace :migrate do
     analytics_count = targetted_codes_from_analytics_events.count
 
     if analytics_count.zero?
-      Rails.logger.info "delete_analytics_events: No events AnalyticsEvent data found, with those criteria"
+      Rails.logger.info "delete_analytics_events_based_on_assessment_code: No events AnalyticsEvent data found, with those criteria"
     elsif mock
       targetted_codes_from_analytics_events.in_batches(&:delete_all)
-      Rails.logger.info "delete_analytics_events: #{analytics_count} AnalyticsEvent data deleted"
+      Rails.logger.info "delete_analytics_events_based_on_assessment_code: #{analytics_count} AnalyticsEvent data deleted"
     else
-      Rails.logger.info "delete_analytics_events: #{analytics_count} AnalyticsEvent data would have been deleted"
+      Rails.logger.info "delete_analytics_events_based_on_assessment_code: #{analytics_count} AnalyticsEvent data would have been deleted"
     end
-    Rails.logger.info "delete_analytics_events: #{AnalyticsEvent.count} AnalyticsEvent data remain"
+    Rails.logger.info "delete_analytics_events_based_on_assessment_code: #{AnalyticsEvent.count} AnalyticsEvent data remain"
   end
 end

--- a/lib/tasks/delete_analytics_event_via_assessment_code.rake
+++ b/lib/tasks/delete_analytics_event_via_assessment_code.rake
@@ -27,10 +27,10 @@ namespace :migrate do
     if analytics_count.zero?
       Rails.logger.info "delete_analytics_events_based_on_assessment_code: No events AnalyticsEvent data found, with those criteria"
     elsif mock
+      Rails.logger.info "delete_analytics_events_based_on_assessment_code: #{analytics_count} AnalyticsEvent data would have been deleted"
+    else
       targetted_codes_from_analytics_events.in_batches(&:delete_all)
       Rails.logger.info "delete_analytics_events_based_on_assessment_code: #{analytics_count} AnalyticsEvent data deleted"
-    else
-      Rails.logger.info "delete_analytics_events_based_on_assessment_code: #{analytics_count} AnalyticsEvent data would have been deleted"
     end
     Rails.logger.info "delete_analytics_events_based_on_assessment_code: #{AnalyticsEvent.count} AnalyticsEvent data remain"
   end

--- a/lib/tasks/delete_analytics_event_via_assessment_code.rake
+++ b/lib/tasks/delete_analytics_event_via_assessment_code.rake
@@ -1,0 +1,40 @@
+namespace :migrate do
+  desc "EL-2268: Delete unwanted data from AnalyticEvent table based on assessment code"
+  # Rake task to delete unwanted analytics event data.
+  # Call with "rake migrate:delete_analytics_events_based_on_assessment_code[mock]"
+  # e.g. rake "migrate:delete_analytics_events_based_on_assessment_code[false]"
+  # Running with mock=true will output the number of records to be deleted without actually deleting any
+  # (to allow for testing).
+
+  task :delete_analytics_events_based_on_assessment_code, %i[mock] => :environment do |_task, args|
+    if args.count != 1
+      puts "call with rake migrate:delete_analytics_events[mock]"
+      next
+    end
+
+    mock = args[:mock].to_s.downcase.strip != "false"
+    puts "delete_analytics_events: mock=#{mock}"
+
+    codes_to_delete = %w[
+      b5123acb-3582-4dad-9021-0eb6e0bc527f
+      789874e6-a388-4f45-beab-927e1cc8a3d2
+      2d99ea5a-8350-49bf-b0d2-3f6cca958c0f
+    ]
+
+    targetted_codes_from_analytics_events = AnalyticsEvent.where(assessment_code: codes_to_delete)
+    analytics_count = targetted_codes_from_analytics_events.count
+
+    if analytics_count.zero?
+      puts "delete_analytics_events: No events AnalyticsEvent data found, with those criteria"
+      puts "delete_analytics_events: #{AnalyticsEvent.count} AnalyticsEvent data remain"
+    elsif mock
+      targetted_codes_from_analytics_events.in_batches(&:delete_all)
+      puts "delete_analytics_events: #{analytics_count} AnalyticsEvent data deleted"
+      puts "delete_analytics_events: #{AnalyticsEvent.count} AnalyticsEvent data remain"
+    else
+      puts "delete_analytics_events: #{analytics_count} AnalyticsEvent data would have been deleted"
+      puts "delete_analytics_events: #{AnalyticsEvent.count} AnalyticsEvent data remain"
+    end
+  end
+end
+

--- a/lib/tasks/delete_analytics_event_via_assessment_code.rake
+++ b/lib/tasks/delete_analytics_event_via_assessment_code.rake
@@ -8,12 +8,12 @@ namespace :migrate do
 
   task :delete_analytics_events_based_on_assessment_code, %i[mock] => :environment do |_task, args|
     if args.count != 1
-      puts "call with rake migrate:delete_analytics_events[mock]"
+      Rails.logger.info "call with rake migrate:delete_analytics_events[mock]"
       next
     end
 
     mock = args[:mock].to_s.downcase.strip != "false"
-    puts "delete_analytics_events: mock=#{mock}"
+    Rails.logger.info "delete_analytics_events: mock=#{mock}"
 
     codes_to_delete = %w[
       b5123acb-3582-4dad-9021-0eb6e0bc527f
@@ -25,15 +25,15 @@ namespace :migrate do
     analytics_count = targetted_codes_from_analytics_events.count
 
     if analytics_count.zero?
-      puts "delete_analytics_events: No events AnalyticsEvent data found, with those criteria"
-      puts "delete_analytics_events: #{AnalyticsEvent.count} AnalyticsEvent data remain"
+      Rails.logger.info "delete_analytics_events: No events AnalyticsEvent data found, with those criteria"
+      Rails.logger.info "delete_analytics_events: #{AnalyticsEvent.count} AnalyticsEvent data remain"
     elsif mock
       targetted_codes_from_analytics_events.in_batches(&:delete_all)
-      puts "delete_analytics_events: #{analytics_count} AnalyticsEvent data deleted"
-      puts "delete_analytics_events: #{AnalyticsEvent.count} AnalyticsEvent data remain"
+      Rails.logger.info "delete_analytics_events: #{analytics_count} AnalyticsEvent data deleted"
+      Rails.logger.info "delete_analytics_events: #{AnalyticsEvent.count} AnalyticsEvent data remain"
     else
-      puts "delete_analytics_events: #{analytics_count} AnalyticsEvent data would have been deleted"
-      puts "delete_analytics_events: #{AnalyticsEvent.count} AnalyticsEvent data remain"
+      Rails.logger.info "delete_analytics_events: #{analytics_count} AnalyticsEvent data would have been deleted"
+      Rails.logger.info "delete_analytics_events: #{AnalyticsEvent.count} AnalyticsEvent data remain"
     end
   end
 end

--- a/lib/tasks/delete_analytics_event_via_time_frame_open.rake
+++ b/lib/tasks/delete_analytics_event_via_time_frame_open.rake
@@ -17,11 +17,12 @@ namespace :migrate do
 
     duration_threshold_days = 30
 
-    targetted_codes_from_analytics_events = AnalyticsEvent.select("assessment_code, MIN(created_at::date) AS min_date, MAX(created_at::date) AS max_date").group(:assessment_code)
+    targetted_codes_from_analytics_events = AnalyticsEvent
+      .select("assessment_code, MIN(created_at::date) AS min_date, MAX(created_at::date) AS max_date")
+      .group(:assessment_code)
+      .having("MAX(created_at::date) - MIN(created_at::date) > ?", duration_threshold_days)
 
-    assessment_codes_to_delete = targetted_codes_from_analytics_events.select { |record|
-      (record.max_date - record.min_date).to_i > duration_threshold_days
-    }.map(&:assessment_code)
+    assessment_codes_to_delete = targetted_codes_from_analytics_events.map(&:assessment_code)
 
     analytics_count = assessment_codes_to_delete.size
 

--- a/lib/tasks/delete_analytics_event_via_time_frame_open.rake
+++ b/lib/tasks/delete_analytics_event_via_time_frame_open.rake
@@ -17,21 +17,21 @@ namespace :migrate do
 
     duration_threshold_days = 30
 
-    targetted_codes_from_analytics_events = AnalyticsEvent.select('assessment_code, MIN(created_at::date) AS min_date, MAX(created_at::date) AS max_date').group(:assessment_code)
+    targetted_codes_from_analytics_events = AnalyticsEvent.select("assessment_code, MIN(created_at::date) AS min_date, MAX(created_at::date) AS max_date").group(:assessment_code)
 
-    assessment_codes_to_delete = targetted_codes_from_analytics_events.select do |record|
+    assessment_codes_to_delete = targetted_codes_from_analytics_events.select { |record|
       (record.max_date - record.min_date).to_i > duration_threshold_days
-    end.map(&:assessment_code)
+    }.map(&:assessment_code)
 
     analytics_count = assessment_codes_to_delete.size
 
-    if assessment_codes_to_delete.empty? 
+    if assessment_codes_to_delete.empty?
       Rails.logger.info "delete_analytics_events_based_on_time_frame_open: No events AnalyticsEvent data found, with those criteria"
     elsif mock
       Rails.logger.info "delete_analytics_events_based_on_time_frame_open: #{analytics_count} assessment codes (with multiple analytics events) for AnalyticsEvent table would have been deleted"
     else
       AnalyticsEvent.where(assessment_code: assessment_codes_to_delete).in_batches(&:delete_all)
-      Rails.logger.info"delete_analytics_events_based_on_time_frame_open: #{analytics_count} assessment codes (with multiple analytics events) for AnalyticsEvent table have been deleted"
+      Rails.logger.info "delete_analytics_events_based_on_time_frame_open: #{analytics_count} assessment codes (with multiple analytics events) for AnalyticsEvent table have been deleted"
     end
     Rails.logger.info "delete_analytics_events_based_on_time_frame_open: #{AnalyticsEvent.count} AnalyticsEvent data remain"
   end

--- a/lib/tasks/delete_analytics_event_via_time_frame_open.rake
+++ b/lib/tasks/delete_analytics_event_via_time_frame_open.rake
@@ -1,12 +1,12 @@
 namespace :migrate do
-  desc "EL-2268: Delete unwanted data from AnalyticEvent table based on assessment code"
+  desc "EL-2268: Delete unwanted data from AnalyticEvent table based on the time frame they are open"
   # Rake task to delete unwanted analytics event data.
-  # Call with "rake migrate:delete_analytics_events_based_on_assessment_code[mock]"
-  # e.g. rake "migrate:delete_analytics_events_based_on_assessment_code[false]"
+  # Call with "rake migrate:delete_analytics_events_based_on_time_frame_open[mock]"
+  # e.g. rake "migrate:delete_analytics_events_based_on_time_frame_open[false]"
   # Running with mock=true will output the number of records to be deleted without actually deleting any
   # (to allow for testing).
 
-  task :delete_analytics_events_based_on_assessment_code, %i[mock] => :environment do |_task, args|
+  task :delete_analytics_events_based_on_time_frame_open, %i[mock] => :environment do |_task, args|
     if args.count != 1
       Rails.logger.info "call with rake migrate:delete_analytics_events[mock]"
       next
@@ -21,13 +21,13 @@ namespace :migrate do
       2d99ea5a-8350-49bf-b0d2-3f6cca958c0f
     ]
 
-    targetted_codes_from_analytics_events = AnalyticsEvent.where(assessment_code: codes_to_delete)
-    analytics_count = targetted_codes_from_analytics_events.count
+    targetted_data_from_analytics_events = AnalyticsEvent.where(assessment_code: codes_to_delete)
+    analytics_count = targetted_data_from_analytics_events.count
 
     if analytics_count.zero?
       Rails.logger.info "delete_analytics_events: No events AnalyticsEvent data found, with those criteria"
     elsif mock
-      targetted_codes_from_analytics_events.in_batches(&:delete_all)
+      targetted_data_from_analytics_events.in_batches(&:delete_all)
       Rails.logger.info "delete_analytics_events: #{analytics_count} AnalyticsEvent data deleted"
     else
       Rails.logger.info "delete_analytics_events: #{analytics_count} AnalyticsEvent data would have been deleted"

--- a/lib/tasks/delete_feedback.rake
+++ b/lib/tasks/delete_feedback.rake
@@ -1,7 +1,7 @@
 namespace :migrate do
   desc "EL-2213: Delete unwanted feedback from Satisfaction Feedback table"
   # Rake task to delete unwanted feedback.
-  # Call with "rake migrate:delete_feecback[mock, 'start_date_time', 'end_date_time']"
+  # Call with "rake migrate:delete_feedback[mock, 'start_date_time', 'end_date_time']"
   # e.g. rake "migrate:delete_feedback[false, '2025-04-24 14:26:00', '2025-04-24 14:27:00']"
   # Running with mock=true will output the number of records to be deleted without actually deleting any
   # (to allow for testing).


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-2268)

## What changed and why

- If applied, this adds 2 rake tasks to delete unwanted AnalyticEvent data.

## Guidance to review

- Will have 2 rake tasks;
  1. to delete AnalyticEvent data by specific assessment codes
  2. to delete AnalyticEvent data by how long the event data has been open (30 days or more to be removed)
      - this will also remove AnalyticEvent data where there is an incorrect assessment code 


- You will have to take a copy of [production DB and restore it locally ](https://dsdmoj.atlassian.net/wiki/spaces/laagetaccess/pages/5761859722/Taking+a+copy+of+the+CCQ+production+database+and+restoring+locally) in order to verify you are targeting the correct data. 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
