### PR TITLE
EL-2268: Delete SQL attack data from AnalyticEvent table - Part 2

### DIFF
--- a/lib/tasks/delete_analytics_event_via_time_frame_open.rake
+++ b/lib/tasks/delete_analytics_event_via_time_frame_open.rake
@@ -19,6 +19,7 @@ namespace :migrate do
 
     targetted_codes_from_analytics_events = AnalyticsEvent
       .select("assessment_code, MIN(created_at::date) AS min_date, MAX(created_at::date) AS max_date")
+      .where.not(assessment_code: nil)
       .group(:assessment_code)
       .having("MAX(created_at::date) - MIN(created_at::date) > ?", duration_threshold_days)
 


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-2268)

## What changed and why

- If applied, this updates the rake task to exclude AnalyticsEvent data where the assessment_code is nil. There are scenarios where having this no assessment code can exist (i.e user is on index page, cookies, privacy etc before starting a check).

## Guidance to review

- n/a

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
