### PR TITLE
EL-2181: Update `disposable_income_summary` FactoryBot to account for `houshold_payments`

### DIFF
--- a/spec/factories/api_results.rb
+++ b/spec/factories/api_results.rb
@@ -181,6 +181,33 @@ FactoryBot.define do
   factory :disposable_income_summary, class: Hash do
     initialize_with { attributes }
     proceeding_types { [build(:proceeding_type)] }
+
+    factory :disposable_income_summary_when_single_and_no_dependants do
+      gross_housing_costs { 600.0 }
+      housing_costs { 600.0 }
+      housing_benefit { 55.0 }
+      net_housing_costs { 545.0 }
+      allowed_housing_costs { 545.0 }
+      total_outgoings_and_allowances { 545.0 }
+      total_disposable_income { -545.0 }
+      combined_total_outgoings_and_allowances { 545.0 }
+      combined_total_disposable_income { -545.0 }
+    end
+
+    factory :disposable_income_summary_with_partner_and_dependants do
+      dependant_allowance { 361.7 }
+      dependant_allowance_under_16 { 361.7 }
+      gross_housing_costs { 600.0 }
+      housing_costs { 600.0 }
+      housing_benefit { 0.0 }
+      net_housing_costs { 600.0 }
+      allowed_housing_costs { 600.0 }
+      total_outgoings_and_allowances { 1186.57 }
+      total_disposable_income { -1186.57 }
+      combined_total_outgoings_and_allowances { 1186.57 }
+      combined_total_disposable_income { -1186.57 }
+      partner_allowance { 224.87 }
+    end
   end
 
   factory :capital_summary, class: Hash do

--- a/spec/views/results_page/housing_outgoings_content_spec.rb
+++ b/spec/views/results_page/housing_outgoings_content_spec.rb
@@ -26,25 +26,7 @@ RSpec.describe "results/show.html.slim" do
           gross_income: {
             proceeding_types: [],
           },
-          disposable_income: {
-            gross_housing_costs: 600.0,
-            housing_costs: 600.0,
-            net_housing_costs: 545.0,
-            allowed_housing_costs: 545.0,
-            total_outgoings_and_allowances: 545.0,
-            total_disposable_income: -545.0,
-            proceeding_types: [
-              {
-                ccms_code: "SE003",
-                upper_threshold: 733.0,
-                lower_threshold: 733.0,
-                result: "eligible",
-                client_involvement_type: "A",
-              },
-            ],
-            combined_total_disposable_income: -545.0,
-            combined_total_outgoings_and_allowances: 545.0,
-          },
+          disposable_income: build(:disposable_income_summary_when_single_and_no_dependants),
           capital: {
             proceeding_types: [],
           },
@@ -110,29 +92,7 @@ RSpec.describe "results/show.html.slim" do
             gross_income: {
               proceeding_types: [],
             },
-            disposable_income: {
-              dependant_allowance_under_16: 361.7,
-              dependant_allowance: 361.7,
-              gross_housing_costs: 600.0,
-              housing_costs: 600.0,
-              housing_benefit: 0.0,
-              net_housing_costs: 600.0,
-              allowed_housing_costs: 600.0,
-              total_outgoings_and_allowances: 1186.57,
-              total_disposable_income: -1186.57,
-              proceeding_types: [
-                {
-                  ccms_code: "SE003",
-                  upper_threshold: 733.0,
-                  lower_threshold: 733.0,
-                  result: "eligible",
-                  client_involvement_type: "A",
-                },
-              ],
-              combined_total_disposable_income: -1186.57,
-              combined_total_outgoings_and_allowances: 1186.57,
-              partner_allowance: 224.87,
-            },
+            disposable_income: build(:disposable_income_summary_with_partner_and_dependants),
             capital: {
               proceeding_types: [],
             },


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-2181)

## What changed and why

- If applied, this adds a FactoryBot for `disposable_income_summary` section for household payments

## Guidance to review

- n/a

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
