### PR TITLE
Add latest tag to ECR images for main builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,7 +263,7 @@ jobs:
       - run:
           name: Set ECR_TAG environment variable for use in next step
           command: |
-            [[ "$CIRCLE_BRANCH" == "main" ]] && ECR_TAG="main-$CIRCLE_SHA1" || ECR_TAG="branch-$CIRCLE_SHA1"
+            [[ "$CIRCLE_BRANCH" == "main" ]] && ECR_TAG="main-$CIRCLE_SHA1,latest" || ECR_TAG="branch-$CIRCLE_SHA1"
             echo "export ECR_TAG=$ECR_TAG" >> "$BASH_ENV"
             source "$BASH_ENV"
       - aws-ecr/build_image:


### PR DESCRIPTION
- Changes nothing about how CCQ deploys
- Adds the `latest` tag to each `main` branch build so that the `latest` image can be pulled for services actively developing against the new embedded mode (RCW).