### PR TITLE
feat: :sparkles: Adding stubbing for Host Service Client and getting majority of flow working in Embedded mode

### DIFF
--- a/app/controllers/embedded_landings_controller.rb
+++ b/app/controllers/embedded_landings_controller.rb
@@ -7,7 +7,7 @@ class EmbeddedLandingsController < EmbeddedBaseController
 
     case response.status
     when 200
-      body = JSON.parse(response.body)
+      body = response.body.is_a?(String) ? JSON.parse(response.body) : response.body
       journey_store.init({
         "feature_flags" => FeatureFlags.session_flags,
         "return_url" => body.fetch("return_url"),

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -66,6 +66,13 @@ module FormsHelper
                else
                  [controller_name, action_name].join("_")
                end
-    document_path(document, sub_section:, assessment_code: params[:assessment_code], referrer:)
+    route_params = {
+      sub_section:,
+      referrer:,
+      assessment_code: params[:assessment_code],
+      resource_id: params[:resource_id],
+    }.compact
+
+    document_path(document, route_params)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,13 @@ Rails.application.routes.draw do
   resources :status, only: [:index]
   get "/health", to: "status#health"
   get "robots.txt", to: "robots#index"
+  resource :cookies, only: %i[show update]
+  resource :help, only: :show
+  resource :privacy, as: :privacy, only: :show
+  resource :accessibility, only: :show
+  resources :updates, only: :index
+  resources :documents, only: :show
+  resources :feedbacks, only: %i[create update]
 
   if ModeConfig.embedded?
     root to: "status#index"
@@ -41,17 +48,8 @@ Rails.application.routes.draw do
   if ModeConfig.standalone?
     root to: "start#index"
     resources :start, only: [:index]
-
-    resource :cookies, only: %i[show update]
-    resource :privacy, as: :privacy, only: :show
-    resource :accessibility, only: :show
-    resource :help, only: :show
     resources :feature_flags, only: %i[index], path: "feature-flags"
-    resources :updates, only: :index
     resources :basic_authentication_sessions, only: %i[new create]
-    resources :documents, only: :show
-    resources :feedbacks, only: %i[create update]
-
     get "/no-analytics", to: "cookies#no_analytics_mode"
     get "instant-:session_type", to: "instant_sessions#create", as: :instant_session
 
@@ -100,7 +98,6 @@ Rails.application.routes.draw do
     # Landing route — entry point from the host service
     scope "/applications/:resource_id/eligibility" do
       get "/", to: "embedded_landings#show", as: :landing
-
       get "check-answers", to: "embedded_checks#check_answers", as: :check_answers
       get "check-result", to: "embedded_results#show", as: :result
       post "check-result", to: "embedded_results#create"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
     depends_on:
       redis:
         condition: service_healthy
+      host-service-stub:
+        condition: service_started
     environment:
       RAILS_ENV: production
       RAILS_SERVE_STATIC_FILES: true # won't serve assets without this
@@ -33,6 +35,17 @@ services:
 
       CCQ_MODE: embedded
       REDIS_URL: redis://redis:6379
+      HOST_SERVICE_URL: http://host-service-stub:8080
+      HOST_SERVICE_LOAD_ENDPOINT: /api/private/load
+      HOST_SERVICE_SAVE_ENDPOINT: /api/private/save
+
+  host-service-stub:
+    container_name: ccq-host-service-stub
+    image: wiremock/wiremock:3.13.1
+    volumes:
+      - ./docker/compose/host-service-stub/mappings:/home/wiremock/mappings:ro
+    command:
+      - --global-response-templating
 
   redis:
     container_name: ccq-embedded-redis

--- a/docker/compose/host-service-stub/mappings/load.json
+++ b/docker/compose/host-service-stub/mappings/load.json
@@ -1,0 +1,15 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/api/private/load"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "return_url": "http://localhost:8080/"
+    }
+  }
+}

--- a/docker/compose/host-service-stub/mappings/save.json
+++ b/docker/compose/host-service-stub/mappings/save.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/api/private/save"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {}
+  }
+}

--- a/docker/compose/nginx/proxy.conf
+++ b/docker/compose/nginx/proxy.conf
@@ -10,6 +10,10 @@ proxy_set_header       X-Real-IP         $remote_addr;
 proxy_set_header       X-Forwarded-For   $proxy_add_x_forwarded_for;
 proxy_set_header       X-Forwarded-Proto $proxy_x_forwarded_proto;
 proxy_set_header       X-Forwarded-Port  $proxy_x_forwarded_port;
+proxy_set_header       X-Forwarded-Host  $http_host;
+
+# Preserve localhost port in upstream absolute redirects when running via docker compose.
+proxy_redirect         http://localhost/ http://localhost:8080/;
 
 # Tracing
 proxy_set_header       X-Request-Id      $http_x_request_id;

--- a/spec/controllers/embedded_landings_controller_spec.rb
+++ b/spec/controllers/embedded_landings_controller_spec.rb
@@ -60,5 +60,19 @@ RSpec.describe EmbeddedLandingsController, ccq_mode: :embedded, type: :controlle
       expect(response).to have_http_status(:service_unavailable)
       expect(response).to render_template("errors/service_unavailable")
     end
+
+    context "when host service response body is already parsed" do
+      let(:response_body) { { "return_url" => "http://example.com/return" } }
+
+      it "initializes journey data and redirects without JSON parsing" do
+        get :show, params: { resource_id: }
+
+        expect(journey_store).to have_received(:init).at_least(:once).with({
+          "feature_flags" => FeatureFlags.session_flags,
+          "return_url" => "http://example.com/return",
+        })
+        expect(response).to redirect_to(step_path(resource_id:, step_url_fragment:))
+      end
+    end
   end
 end


### PR DESCRIPTION
## What changed and why

feat: ✨ Add stub for host service
feat: 🚚 Adding explicit proxy_redirect for localhost to preserve the associated port when running locally using Docker
feat: ✨ Updating document_link to pass across resource_id as a route parameter
feat: 🚚 Moving resources in routes.rb out of the standalone block to get the flow working
fix: 🐛 Fixing parsing bug in landing controller
test: ✅ Adding test coverage for JSON parsing branch in embedded_landing_controller

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing
- Branch is generally up to date with main Github - definitely no conflicts
- No unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- PR description says *what* changed and *why*, with a link to the JIRA story.
- Diff has been checked for unexpected changes being included.
- Commit messages say why the change was made.
