### PR TITLE
Add fallback variable which persists the port during proxying locally

### DIFF
--- a/docker/compose/nginx/maps.conf
+++ b/docker/compose/nginx/maps.conf
@@ -21,3 +21,9 @@ map $http_x_forwarded_port $proxy_x_forwarded_port {
     default $http_x_forwarded_port;
     ''      $server_port;
 }
+
+# preserve incoming Host header (including optional port), with a safe fallback
+map $http_host $proxy_host {
+    default $http_host;
+    ''      $host;
+}

--- a/docker/compose/nginx/proxy.conf
+++ b/docker/compose/nginx/proxy.conf
@@ -5,7 +5,8 @@ proxy_set_header       Transfer-Encoding "";
 proxy_hide_header      X-Powered-By;
 
 # Forwarding Identity and State
-proxy_set_header       Host              $host;
+# Preserve incoming host and optional port (for local non-standard ports like :8080).
+proxy_set_header       Host              $proxy_host;
 proxy_set_header       X-Real-IP         $remote_addr;
 proxy_set_header       X-Forwarded-For   $proxy_add_x_forwarded_for;
 proxy_set_header       X-Forwarded-Proto $proxy_x_forwarded_proto;


### PR DESCRIPTION
Configures nginx to proxy using the incoming host header when available, to avoid stripping the port number.