### PR TITLE
Restrict metabase in staging and production to Alpha VPN access only

### DIFF
--- a/helm_deploy/laa-estimate-eligibility/templates/ingress.yaml
+++ b/helm_deploy/laa-estimate-eligibility/templates/ingress.yaml
@@ -22,10 +22,6 @@ spec:
       secretName: '{{- .secret }}'
     {{- end }}
   {{- end }}
-  {{- if .Values.metabase.enabled }}
-    - hosts:
-      - "ccq-dashboard-{{ .Values.cfe.environment_name }}.cloud-platform.service.justice.gov.uk"
-  {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
     - host: '{{- .host }}'
@@ -39,16 +35,4 @@ spec:
                 port:
                   name: http
   {{- end }}
-    {{- if .Values.metabase.enabled }}
-    - host: "ccq-dashboard-{{ .Values.cfe.environment_name }}.cloud-platform.service.justice.gov.uk"
-      http:
-        paths:
-          - path: "/"
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: {{ $fullName }}-metabase
-                port:
-                  number: 80
-    {{- end }}
 

--- a/helm_deploy/laa-estimate-eligibility/templates/metabase/metabase-ingress.yaml
+++ b/helm_deploy/laa-estimate-eligibility/templates/metabase/metabase-ingress.yaml
@@ -1,28 +1,17 @@
 {{- if .Values.metabase.enabled }}
-{{- $fullName := include "app.fullname" . -}}
-{{- $ingressName := printf "%s-metabase" $fullName -}}
+{{- $ingressName := printf "%s-metabase" (include "app.fullname" .) -}}
 {{- $metabaseValues := .Values.metabase | default dict -}}
-{{- $metabaseIngressValues := get $metabaseValues "ingress" | default dict -}}
-{{- $metabaseHost := get $metabaseIngressValues "host" | default (printf "ccq-dashboard-%s.cloud-platform.service.justice.gov.uk" .Values.environment) -}}
+{{- $metabaseIngress := get $metabaseValues "ingress" | default dict -}}
+{{- $metabaseHost := default (printf "ccq-dashboard-%s.cloud-platform.service.justice.gov.uk" .Values.environment) (get $metabaseIngress "host") -}}
 
-{{- /* Start with shared ingress annotations, then layer any metabase-specific overrides. */ -}}
-{{- $metabaseAnnotations := merge (dict) (.Values.ingress.annotations | default dict) (get $metabaseIngressValues "annotations" | default dict) -}}
+{{- $annotations := merge (dict) (.Values.ingress.annotations | default dict) (get $metabaseIngress "annotations" | default dict) -}}
+{{- $sharedSetIdentifier := get $annotations "external-dns.alpha.kubernetes.io/set-identifier" | default "" -}}
+{{- $clusterColor := ternary (last (splitList "-" $sharedSetIdentifier)) "green" (ne $sharedSetIdentifier "") -}}
 
-{{- /* Gatekeeper expects: <ingress-name>-<namespace>-<clusterColor>. */ -}}
-{{- $setIdentifierAnnotationKey := "external-dns.alpha.kubernetes.io/set-identifier" -}}
-{{- $clusterColor := "green" -}}
-{{- $sharedSetIdentifier := index $metabaseAnnotations $setIdentifierAnnotationKey | default "" -}}
+{{- $_ := set $annotations "external-dns.alpha.kubernetes.io/set-identifier" (printf "%s-%s-%s" $ingressName .Release.Namespace $clusterColor) -}}
 
-{{- if ne $sharedSetIdentifier "" -}}
-{{- $clusterColor = last (splitList "-" $sharedSetIdentifier) -}}
-{{- end -}}
-
-{{- $metabaseSetIdentifier := printf "%s-%s-%s" $ingressName .Release.Namespace $clusterColor -}}
-{{- $_ := set $metabaseAnnotations $setIdentifierAnnotationKey $metabaseSetIdentifier -}}
-
-{{- $allowedIpRanges := get $metabaseIngressValues "allowed_ip_ranges" | default (list) -}}
-{{- if gt (len $allowedIpRanges) 0 -}}
-{{- $_ := set $metabaseAnnotations "nginx.ingress.kubernetes.io/whitelist-source-range" (join "," $allowedIpRanges) -}}
+{{- with get $metabaseIngress "allowed_ip_ranges" -}}
+{{- $_ := set $annotations "nginx.ingress.kubernetes.io/whitelist-source-range" (join "," .) -}}
 {{- end -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -33,7 +22,7 @@ metadata:
     chart: {{ template "app.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- with $metabaseAnnotations }}
+{{- with $annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/helm_deploy/laa-estimate-eligibility/templates/metabase/metabase-ingress.yaml
+++ b/helm_deploy/laa-estimate-eligibility/templates/metabase/metabase-ingress.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.metabase.enabled }}
+{{- $fullName := include "app.fullname" . -}}
+{{- $metabase := .Values.metabase | default dict -}}
+{{- $metabaseIngress := get $metabase "ingress" | default dict -}}
+{{- $metabaseHost := get $metabaseIngress "host" | default (printf "ccq-dashboard-%s.cloud-platform.service.justice.gov.uk" .Values.environment) -}}
+{{- $metabaseAnnotations := merge (dict) (.Values.ingress.annotations | default dict) (get $metabaseIngress "annotations" | default dict) -}}
+{{- $metabaseIngressAllowedIpRanges := get $metabaseIngress "allowed_ip_ranges" | default (list) -}}
+{{- if gt (len $metabaseIngressAllowedIpRanges) 0 -}}
+{{- $metabaseAnnotations = merge $metabaseAnnotations (dict "nginx.ingress.kubernetes.io/whitelist-source-range" (join "," $metabaseIngressAllowedIpRanges)) -}}
+{{- end -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-metabase
+  labels:
+    app: {{ template "app.name" . }}
+    chart: {{ template "app.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with $metabaseAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  ingressClassName: default
+  tls:
+    - hosts:
+        - '{{ $metabaseHost }}'
+  rules:
+    - host: '{{ $metabaseHost }}'
+      http:
+        paths:
+          - path: "/"
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}-metabase
+                port:
+                  number: 80
+{{- end }}

--- a/helm_deploy/laa-estimate-eligibility/templates/metabase/metabase-ingress.yaml
+++ b/helm_deploy/laa-estimate-eligibility/templates/metabase/metabase-ingress.yaml
@@ -1,17 +1,33 @@
 {{- if .Values.metabase.enabled }}
 {{- $fullName := include "app.fullname" . -}}
-{{- $metabase := .Values.metabase | default dict -}}
-{{- $metabaseIngress := get $metabase "ingress" | default dict -}}
-{{- $metabaseHost := get $metabaseIngress "host" | default (printf "ccq-dashboard-%s.cloud-platform.service.justice.gov.uk" .Values.environment) -}}
-{{- $metabaseAnnotations := merge (dict) (.Values.ingress.annotations | default dict) (get $metabaseIngress "annotations" | default dict) -}}
-{{- $metabaseIngressAllowedIpRanges := get $metabaseIngress "allowed_ip_ranges" | default (list) -}}
-{{- if gt (len $metabaseIngressAllowedIpRanges) 0 -}}
-{{- $metabaseAnnotations = merge $metabaseAnnotations (dict "nginx.ingress.kubernetes.io/whitelist-source-range" (join "," $metabaseIngressAllowedIpRanges)) -}}
+{{- $ingressName := printf "%s-metabase" $fullName -}}
+{{- $metabaseValues := .Values.metabase | default dict -}}
+{{- $metabaseIngressValues := get $metabaseValues "ingress" | default dict -}}
+{{- $metabaseHost := get $metabaseIngressValues "host" | default (printf "ccq-dashboard-%s.cloud-platform.service.justice.gov.uk" .Values.environment) -}}
+
+{{- /* Start with shared ingress annotations, then layer any metabase-specific overrides. */ -}}
+{{- $metabaseAnnotations := merge (dict) (.Values.ingress.annotations | default dict) (get $metabaseIngressValues "annotations" | default dict) -}}
+
+{{- /* Gatekeeper expects: <ingress-name>-<namespace>-<clusterColor>. */ -}}
+{{- $setIdentifierAnnotationKey := "external-dns.alpha.kubernetes.io/set-identifier" -}}
+{{- $clusterColor := "green" -}}
+{{- $sharedSetIdentifier := index $metabaseAnnotations $setIdentifierAnnotationKey | default "" -}}
+
+{{- if ne $sharedSetIdentifier "" -}}
+{{- $clusterColor = last (splitList "-" $sharedSetIdentifier) -}}
+{{- end -}}
+
+{{- $metabaseSetIdentifier := printf "%s-%s-%s" $ingressName .Release.Namespace $clusterColor -}}
+{{- $_ := set $metabaseAnnotations $setIdentifierAnnotationKey $metabaseSetIdentifier -}}
+
+{{- $allowedIpRanges := get $metabaseIngressValues "allowed_ip_ranges" | default (list) -}}
+{{- if gt (len $allowedIpRanges) 0 -}}
+{{- $_ := set $metabaseAnnotations "nginx.ingress.kubernetes.io/whitelist-source-range" (join "," $allowedIpRanges) -}}
 {{- end -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}-metabase
+  name: {{ $ingressName }}
   labels:
     app: {{ template "app.name" . }}
     chart: {{ template "app.chart" . }}
@@ -34,7 +50,7 @@ spec:
             pathType: ImplementationSpecific
             backend:
               service:
-                name: {{ $fullName }}-metabase
+                name: {{ $ingressName }}
                 port:
                   number: 80
 {{- end }}

--- a/helm_deploy/laa-estimate-eligibility/values/ccq-production.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/ccq-production.yaml
@@ -10,6 +10,7 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+environment: production
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -87,5 +88,11 @@ google:
 
 metabase:
   enabled: true
-
-
+  ingress:
+    allowed_ip_ranges: [
+        # Gateway IP for Global Protect alpha VPN firewall
+        "35.176.93.186/32",
+        "18.169.147.172/32",
+        "18.130.148.126/32",
+        "35.176.148.126/32",
+      ]

--- a/helm_deploy/laa-estimate-eligibility/values/ccq-staging.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/ccq-staging.yaml
@@ -10,6 +10,7 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+environment: staging
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -42,10 +43,10 @@ service:
 
 ingress:
   hosts:
-   - host: check-your-client-qualifies-for-legal-aid-staging.cloud-platform.service.justice.gov.uk
-     secret: false
-   - host: staging.check-your-client-qualifies-for-legal-aid.service.gov.uk
-     secret: ccq-staging-cert-secret
+    - host: check-your-client-qualifies-for-legal-aid-staging.cloud-platform.service.justice.gov.uk
+      secret: false
+    - host: staging.check-your-client-qualifies-for-legal-aid.service.gov.uk
+      secret: ccq-staging-cert-secret
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: "check-client-qualifies-laa-estimate-eligibility-laa-check-client-qualifies-staging-green"
     external-dns.alpha.kubernetes.io/aws-weight: "100"
@@ -87,3 +88,11 @@ google:
 
 metabase:
   enabled: true
+  ingress:
+    allowed_ip_ranges: [
+        # Gateway IPs for Global Protect alpha VPN firewall
+        "35.176.93.186/32",
+        "18.169.147.172/32",
+        "18.130.148.126/32",
+        "35.176.148.126/32",
+      ]

--- a/helm_deploy/laa-estimate-eligibility/values/ccq-uat.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/ccq-uat.yaml
@@ -110,12 +110,4 @@ google:
   oauthRedirectUri: https://main-check-client-qualifies-legal-aid-uat.cloud-platform.service.justice.gov.uk/auth/subdomain_redirect
 
 metabase:
-  enabled: true
-  ingress:
-    allowed_ip_ranges: [
-        # Gateway IPs for Global Protect alpha VPN firewall
-        "35.176.93.186/32",
-        "18.169.147.172/32",
-        "18.130.148.126/32",
-        "35.176.148.126/32",
-      ]
+  enabled: false

--- a/helm_deploy/laa-estimate-eligibility/values/ccq-uat.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/ccq-uat.yaml
@@ -14,6 +14,7 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+environment: uat
 
 nodeSelector: {}
 

--- a/helm_deploy/laa-estimate-eligibility/values/ccq-uat.yaml
+++ b/helm_deploy/laa-estimate-eligibility/values/ccq-uat.yaml
@@ -110,4 +110,12 @@ google:
   oauthRedirectUri: https://main-check-client-qualifies-legal-aid-uat.cloud-platform.service.justice.gov.uk/auth/subdomain_redirect
 
 metabase:
-  enabled: false
+  enabled: true
+  ingress:
+    allowed_ip_ranges: [
+        # Gateway IPs for Global Protect alpha VPN firewall
+        "35.176.93.186/32",
+        "18.169.147.172/32",
+        "18.130.148.126/32",
+        "35.176.148.126/32",
+      ]


### PR DESCRIPTION
CCQ's Metabase needs access restriction as an additional security measure. Metabase is currently accessible using the same ingress resource as CCQ itself.

---
This PR moves metabase onto its own ingress, with access restricted to the MoJ VPN.

Tested by enabling metabase in UAT, instantiating resources it depends on to start, testing response codes both on and off the VPN. On the VPN, metabase is accessible, off the VPN we get `403` from the cluster.

> [!NOTE]
> CD didn't fully fail during testing, there's an RDS secret which metabase depends on in staging/prod that doesn't exist in UAT because UAT doesn't use RDS. After adding the secret manually and rolling the metabase pod, it spun up. CD failed because it timed out waiting for the metabase pod to become healthy. All of this has been cleaned up.

> [!IMPORTANT]
> **This needs testing in staging prior to production release as well.**