### PR TITLE
Update puppeteer upgrade workflow

### DIFF
--- a/.github/workflows/browser_tools_docker_image.yml
+++ b/.github/workflows/browser_tools_docker_image.yml
@@ -3,12 +3,38 @@ on:
   push:
     branches:
       - main
-      - puppeteer-2521
+      - puppeteer-*
+    paths:
+      - Dockerfile_browser_tools.dockerfile
+
+permissions:
+  contents: read
 
 jobs:
   build-push:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate branch and actor policy
+        run: |
+          set -eu
+
+          ref_name="${GITHUB_REF_NAME}"
+          actor="${GITHUB_ACTOR}"
+
+          if [ "${ref_name}" = "main" ]; then
+            exit 0
+          fi
+
+          if ! echo "${ref_name}" | grep -Eq '^puppeteer-[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Ref '${ref_name}' is not an allowed Puppeteer branch format." >&2
+            exit 1
+          fi
+
+          if [ "${actor}" != "github-actions[bot]" ]; then
+            echo "Puppeteer branch publishes must be pushed by github-actions[bot], got '${actor}'." >&2
+            exit 1
+          fi
+
       - name: Login to Docker Hub
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:

--- a/.github/workflows/puppeteer_upgrade.yml
+++ b/.github/workflows/puppeteer_upgrade.yml
@@ -40,17 +40,8 @@ jobs:
             exit 1
           fi
 
-          major="${PUPPETEER_VERSION%%.*}"
-          rest="${PUPPETEER_VERSION#*.}"
-          minor="${rest%%.*}"
-          patch="${PUPPETEER_VERSION##*.}"
-
-          tag_suffix="${major}${minor}"
-          if [[ "$patch" != "0" ]]; then
-            tag_suffix="${tag_suffix}${patch}"
-          fi
-
-          branch_name="puppeteer-${tag_suffix}"
+          # Use semver directly for clarity (for example puppeteer-25.2.0).
+          branch_name="puppeteer-${PUPPETEER_VERSION}"
 
           echo "IMAGE_TAG=${branch_name}" >> "$GITHUB_ENV"
           echo "BRANCH_NAME=${branch_name}" >> "$GITHUB_ENV"

--- a/.github/workflows/puppeteer_upgrade.yml
+++ b/.github/workflows/puppeteer_upgrade.yml
@@ -79,10 +79,7 @@ jobs:
           sed -E -i "s|RUN yarn add puppeteer@[^[:space:]]+|RUN yarn add puppeteer@${PUPPETEER_VERSION}|" Dockerfile_browser_tools.dockerfile
 
           # Align requested version branch with CircleCI's test image tag.
-          sed -E -i "s|(checkclientqualifiesdocker/circleci-image:)puppeteer-[0-9]+|\\1${IMAGE_TAG}|g" .circleci/config.yml
-
-          # Align requested version branch with browser-tools image workflow branch trigger.
-          sed -E -i "s|^([[:space:]]*-[[:space:]]*)['\"]?puppeteer-[0-9]+['\"]?$|\\1${IMAGE_TAG}|" .github/workflows/browser_tools_docker_image.yml
+          sed -E -i "s|(checkclientqualifiesdocker/circleci-image:)puppeteer-[0-9]+(\.[0-9]+\.[0-9]+)?|\\1${IMAGE_TAG}|g" .circleci/config.yml
 
       - name: Commit and push changes
         id: commit_changes
@@ -96,7 +93,7 @@ jobs:
             exit 0
           fi
 
-          git add package.json Dockerfile_browser_tools.dockerfile yarn.lock .circleci/config.yml .github/workflows/browser_tools_docker_image.yml
+          git add package.json Dockerfile_browser_tools.dockerfile yarn.lock .circleci/config.yml
           git commit -m "chore: bump puppeteer to ${PUPPETEER_VERSION}"
           git push --force-with-lease origin "$BRANCH_NAME"
 
@@ -114,7 +111,6 @@ jobs:
           - Dockerfile_browser_tools.dockerfile Puppeteer pin updated
           - yarn.lock refreshed with yarn add --exact puppeteer@${PUPPETEER_VERSION}
           - .circleci/config.yml test image updated to ${IMAGE_TAG}
-          - .github/workflows/browser_tools_docker_image.yml branch trigger updated to ${IMAGE_TAG}
 
           The browser tools image workflow will push:
           - checkclientqualifiesdocker/circleci-image:${IMAGE_TAG}


### PR DESCRIPTION
- Allow browsertools image generation workflow to run from any active puppeteer branch
- Use semver for branch name as it's clearer