### PR TITLE
Trigger browser tools build from puppeteer upgrade workflow

### DIFF
--- a/.github/workflows/browser-tools-docker-image-reusable.yml
+++ b/.github/workflows/browser-tools-docker-image-reusable.yml
@@ -1,0 +1,72 @@
+name: "Browsertools docker image reusable"
+
+on:
+  workflow_call:
+    inputs:
+      source_ref:
+        description: Branch or ref to checkout for building the browser tools image.
+        required: true
+        type: string
+      image_tag:
+        description: Docker image tag to publish.
+        required: true
+        type: string
+      source_actor:
+        description: Actor from caller workflow for policy checks.
+        required: false
+        default: ""
+        type: string
+      enforce_actor_policy:
+        description: Enforce github-actions[bot] actor policy for Puppeteer branches.
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate branch and actor policy
+        run: |
+          set -eu
+
+          ref_name='${{ inputs.source_ref }}'
+          actor='${{ inputs.source_actor }}'
+          if [ -z "${actor}" ]; then
+            actor="${GITHUB_ACTOR}"
+          fi
+
+          if [ "${ref_name}" = "main" ]; then
+            exit 0
+          fi
+
+          if ! echo "${ref_name}" | grep -Eq '^puppeteer-[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Ref '${ref_name}' is not an allowed Puppeteer branch format." >&2
+            exit 1
+          fi
+
+          if [ '${{ inputs.enforce_actor_policy }}' = 'true' ] && [ "${actor}" != "github-actions[bot]" ]; then
+            echo "Puppeteer branch publishes must be pushed by github-actions[bot], got '${actor}'." >&2
+            exit 1
+          fi
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USER_CCQ }}
+          password: ${{ secrets.DOCKERHUB_PAT_CCQ }}
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.source_ref }}
+
+      - name: Build the Docker image
+        run: |
+          docker build -f ./Dockerfile_browser_tools.dockerfile . -t checkclientqualifiesdocker/circleci-image:${{ inputs.image_tag }}
+
+      - name: Push the Docker image
+        run: |
+          docker push checkclientqualifiesdocker/circleci-image:${{ inputs.image_tag }}

--- a/.github/workflows/browser_tools_docker_image.yml
+++ b/.github/workflows/browser_tools_docker_image.yml
@@ -13,38 +13,10 @@ permissions:
 
 jobs:
   build-push:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Validate branch and actor policy
-        run: |
-          set -eu
-
-          ref_name="${GITHUB_REF_NAME}"
-          actor="${GITHUB_ACTOR}"
-
-          if [ "${ref_name}" = "main" ]; then
-            exit 0
-          fi
-
-          if ! echo "${ref_name}" | grep -Eq '^puppeteer-[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "Ref '${ref_name}' is not an allowed Puppeteer branch format." >&2
-            exit 1
-          fi
-
-          if [ "${actor}" != "github-actions[bot]" ]; then
-            echo "Puppeteer branch publishes must be pushed by github-actions[bot], got '${actor}'." >&2
-            exit 1
-          fi
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USER_CCQ }}
-          password: ${{ secrets.DOCKERHUB_PAT_CCQ }}
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Build the Docker image
-        run: |
-          docker build -f ./Dockerfile_browser_tools.dockerfile . -t checkclientqualifiesdocker/circleci-image:${{ github.ref_name }}
-      - name: Push the Docker image
-        run: |
-          docker push checkclientqualifiesdocker/circleci-image:${{ github.ref_name }}
+    uses: ./.github/workflows/browser-tools-docker-image-reusable.yml
+    with:
+      source_ref: ${{ github.ref_name }}
+      image_tag: ${{ github.ref_name }}
+      source_actor: ${{ github.actor }}
+      enforce_actor_policy: true
+    secrets: inherit

--- a/.github/workflows/browser_tools_docker_image.yml
+++ b/.github/workflows/browser_tools_docker_image.yml
@@ -6,6 +6,7 @@ on:
       - puppeteer-*
     paths:
       - Dockerfile_browser_tools.dockerfile
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/puppeteer_upgrade.yml
+++ b/.github/workflows/puppeteer_upgrade.yml
@@ -16,10 +16,12 @@ permissions:
 jobs:
   create-upgrade-pr:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash --noprofile --norc -euo pipefail {0}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PUPPETEER_VERSION: ${{ inputs.puppeteer_version }}
-      BASE_BRANCH: main
     steps:
       - name: Checkout base branch
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -29,13 +31,6 @@ jobs:
 
       - name: Validate input and derive branch metadata
         run: |
-          set -euo pipefail
-
-          if [ "${GITHUB_REF_NAME}" != "main" ]; then
-            echo "This workflow must be dispatched from main (got '${GITHUB_REF_NAME}')." >&2
-            exit 1
-          fi
-
           if ! [[ "$PUPPETEER_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Invalid version '$PUPPETEER_VERSION'. Expected semver like 25.2.1" >&2
             exit 1
@@ -54,14 +49,11 @@ jobs:
 
       - name: Create or reset upgrade branch
         run: |
-          set -euo pipefail
-          git fetch origin "$BASE_BRANCH"
-          git checkout -B "$BRANCH_NAME" "origin/$BASE_BRANCH"
+          git fetch origin main
+          git checkout -B "$BRANCH_NAME" "origin/main"
 
       - name: Enable Yarn and update pinned versions
         run: |
-          set -euo pipefail
-
           corepack enable
           corepack prepare yarn@1.22.22 --activate
 
@@ -76,7 +68,6 @@ jobs:
       - name: Commit and push changes
         id: commit_changes
         run: |
-          set -euo pipefail
           echo "skip_pr=false" >> "$GITHUB_OUTPUT"
 
           if git diff --quiet; then
@@ -134,8 +125,6 @@ jobs:
       - name: Create or update pull request
         if: steps.commit_changes.outputs.skip_pr != 'true'
         run: |
-          set -euo pipefail
-
           pr_title="chore: bump puppeteer to ${PUPPETEER_VERSION}"
           pr_body=$(cat <<EOF
           Automated Puppeteer upgrade via GitHub Actions.
@@ -151,9 +140,9 @@ jobs:
           EOF
           )
 
-          existing_pr=$(gh pr list --state open --head "$BRANCH_NAME" --base "$BASE_BRANCH" --json number --jq '.[0].number')
+          existing_pr=$(gh pr list --state open --head "$BRANCH_NAME" --base main --json number --jq '.[0].number')
           if [[ -n "$existing_pr" && "$existing_pr" != "null" ]]; then
             gh pr edit "$existing_pr" --title "$pr_title" --body "$pr_body"
           else
-            gh pr create --base "$BASE_BRANCH" --head "$BRANCH_NAME" --title "$pr_title" --body "$pr_body"
+            gh pr create --base main --head "$BRANCH_NAME" --title "$pr_title" --body "$pr_body"
           fi

--- a/.github/workflows/puppeteer_upgrade.yml
+++ b/.github/workflows/puppeteer_upgrade.yml
@@ -9,16 +9,19 @@ on:
         type: string
 
 permissions:
-  actions: write
   contents: write
   pull-requests: write
 
 jobs:
-  create-upgrade-pr:
+  prepare-upgrade:
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash --noprofile --norc -euo pipefail {0}
+    outputs:
+      skip_pr: ${{ steps.commit_changes.outputs.skip_pr }}
+      branch_name: ${{ steps.meta.outputs.branch_name }}
+      image_tag: ${{ steps.meta.outputs.image_tag }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PUPPETEER_VERSION: ${{ inputs.puppeteer_version }}
@@ -30,7 +33,13 @@ jobs:
           fetch-depth: 0
 
       - name: Validate input and derive branch metadata
+        id: meta
         run: |
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "This workflow must be dispatched from main (got '${GITHUB_REF_NAME}')." >&2
+            exit 1
+          fi
+
           if ! [[ "$PUPPETEER_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Invalid version '$PUPPETEER_VERSION'. Expected semver like 25.2.1" >&2
             exit 1
@@ -39,6 +48,8 @@ jobs:
           # Use semver directly for clarity (for example puppeteer-25.2.0).
           branch_name="puppeteer-${PUPPETEER_VERSION}"
 
+          echo "branch_name=${branch_name}" >> "$GITHUB_OUTPUT"
+          echo "image_tag=${branch_name}" >> "$GITHUB_OUTPUT"
           echo "IMAGE_TAG=${branch_name}" >> "$GITHUB_ENV"
           echo "BRANCH_NAME=${branch_name}" >> "$GITHUB_ENV"
 
@@ -80,50 +91,35 @@ jobs:
           git commit -m "chore: bump puppeteer to ${PUPPETEER_VERSION}"
           git push --force-with-lease origin "$BRANCH_NAME"
 
-      - name: Trigger browser tools image build workflow
-        id: dispatch_browser_tools
-        if: steps.commit_changes.outputs.skip_pr != 'true'
-        run: |
-          set -euo pipefail
+  build-browser-tools-image:
+    needs: prepare-upgrade
+    if: needs.prepare-upgrade.outputs.skip_pr != 'true'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/browser-tools-docker-image-reusable.yml
+    with:
+      source_ref: ${{ needs.prepare-upgrade.outputs.branch_name }}
+      image_tag: ${{ needs.prepare-upgrade.outputs.image_tag }}
+      source_actor: ${{ github.actor }}
+      enforce_actor_policy: false
+    secrets: inherit
 
-          dispatch_marker="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          echo "dispatch_marker=${dispatch_marker}" >> "$GITHUB_OUTPUT"
-
-          gh workflow run browser_tools_docker_image.yml --ref "$BRANCH_NAME"
-
-      - name: Wait for browser tools image build workflow
-        if: steps.commit_changes.outputs.skip_pr != 'true'
-        env:
-          DISPATCH_MARKER: ${{ steps.dispatch_browser_tools.outputs.dispatch_marker }}
-        run: |
-          set -euo pipefail
-
-          run_id=""
-          for _ in $(seq 1 30); do
-            run_id="$(gh run list \
-              --workflow browser_tools_docker_image.yml \
-              --branch "$BRANCH_NAME" \
-              --event workflow_dispatch \
-              --limit 20 \
-              --json databaseId,createdAt \
-              --jq ".[] | select(.createdAt >= \"${DISPATCH_MARKER}\") | .databaseId" | head -n1)"
-
-            if [ -n "${run_id}" ]; then
-              break
-            fi
-
-            sleep 10
-          done
-
-          if [ -z "${run_id}" ]; then
-            echo "Unable to find dispatched browser_tools_docker_image workflow run for ${BRANCH_NAME}." >&2
-            exit 1
-          fi
-
-          gh run watch "${run_id}" --exit-status
-
+  create-upgrade-pr:
+    needs:
+      - prepare-upgrade
+      - build-browser-tools-image
+    if: needs.prepare-upgrade.outputs.skip_pr != 'true' && needs.build-browser-tools-image.result == 'success'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash --noprofile --norc -euo pipefail {0}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PUPPETEER_VERSION: ${{ inputs.puppeteer_version }}
+      BRANCH_NAME: ${{ needs.prepare-upgrade.outputs.branch_name }}
+      IMAGE_TAG: ${{ needs.prepare-upgrade.outputs.image_tag }}
+    steps:
       - name: Create or update pull request
-        if: steps.commit_changes.outputs.skip_pr != 'true'
         run: |
           pr_title="chore: bump puppeteer to ${PUPPETEER_VERSION}"
           pr_body=$(cat <<EOF

--- a/.github/workflows/puppeteer_upgrade.yml
+++ b/.github/workflows/puppeteer_upgrade.yml
@@ -7,13 +7,9 @@ on:
         description: Puppeteer version to upgrade to (example 25.2.1)
         required: true
         type: string
-      base_branch:
-        description: Base branch for the PR
-        required: false
-        default: main
-        type: string
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -23,17 +19,22 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PUPPETEER_VERSION: ${{ inputs.puppeteer_version }}
-      BASE_BRANCH: ${{ inputs.base_branch }}
+      BASE_BRANCH: main
     steps:
       - name: Checkout base branch
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ inputs.base_branch }}
+          ref: main
           fetch-depth: 0
 
       - name: Validate input and derive branch metadata
         run: |
           set -euo pipefail
+
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "This workflow must be dispatched from main (got '${GITHUB_REF_NAME}')." >&2
+            exit 1
+          fi
 
           if ! [[ "$PUPPETEER_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Invalid version '$PUPPETEER_VERSION'. Expected semver like 25.2.1" >&2
@@ -87,6 +88,48 @@ jobs:
           git add package.json Dockerfile_browser_tools.dockerfile yarn.lock .circleci/config.yml
           git commit -m "chore: bump puppeteer to ${PUPPETEER_VERSION}"
           git push --force-with-lease origin "$BRANCH_NAME"
+
+      - name: Trigger browser tools image build workflow
+        id: dispatch_browser_tools
+        if: steps.commit_changes.outputs.skip_pr != 'true'
+        run: |
+          set -euo pipefail
+
+          dispatch_marker="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "dispatch_marker=${dispatch_marker}" >> "$GITHUB_OUTPUT"
+
+          gh workflow run browser_tools_docker_image.yml --ref "$BRANCH_NAME"
+
+      - name: Wait for browser tools image build workflow
+        if: steps.commit_changes.outputs.skip_pr != 'true'
+        env:
+          DISPATCH_MARKER: ${{ steps.dispatch_browser_tools.outputs.dispatch_marker }}
+        run: |
+          set -euo pipefail
+
+          run_id=""
+          for _ in $(seq 1 30); do
+            run_id="$(gh run list \
+              --workflow browser_tools_docker_image.yml \
+              --branch "$BRANCH_NAME" \
+              --event workflow_dispatch \
+              --limit 20 \
+              --json databaseId,createdAt \
+              --jq ".[] | select(.createdAt >= \"${DISPATCH_MARKER}\") | .databaseId" | head -n1)"
+
+            if [ -n "${run_id}" ]; then
+              break
+            fi
+
+            sleep 10
+          done
+
+          if [ -z "${run_id}" ]; then
+            echo "Unable to find dispatched browser_tools_docker_image workflow run for ${BRANCH_NAME}." >&2
+            exit 1
+          fi
+
+          gh run watch "${run_id}" --exit-status
 
       - name: Create or update pull request
         if: steps.commit_changes.outputs.skip_pr != 'true'


### PR DESCRIPTION
- Defaults puppeteer upgrade base ref to `main` instead of being configurable
- Adds a reusable browser tools build workflow 
- Call the reusable workflow from the puppeteer upgrade workflow
- Call the reusable workflow from the original browser tools workflow to maintain the original upgrade flow