### PR TITLE
Split docker-compose into composable includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ CCQ_MODE=embedded CCQ_EMBEDDED_LAYOUT=rcw/application bin/dev
 ## Run with Docker Compose
 The docker compose configuration is designed to enable you to run both standalone and embedded mode versions of CCQ side by side using the same underlying image.
 
+`docker-compose.yml` composes `docker-compose.embedded.yml` and `docker-compose.standalone.yml` together with a local nginx and host-service stub for testing embedded mode in isolation. Other repos (e.g. RCW) include `docker-compose.embedded.yml` directly, supplying their own host service instead of the stub.
+
 #### Build the app image used by `docker-compose.yml`
 ```bash
 make build

--- a/docker-compose.embedded.yml
+++ b/docker-compose.embedded.yml
@@ -1,0 +1,40 @@
+# Reusable building block: CCQ running in embedded mode, plus its own Redis.
+# Defaults to a real host service (e.g. RCW) at HOST_SERVICE_URL - other repos include this
+# file directly to compose CCQ into their own stack. For standalone testing of embedded mode
+# in isolation, see docker-compose.yml, which overrides HOST_SERVICE_URL to use a stub.
+services:
+  ccq-embedded:
+    container_name: ccq-embedded
+    image: laa-check-client-qualifies:latest
+    platform: linux/amd64
+    pull_policy: never # `make build`
+    expose:
+      - 3000
+    depends_on:
+      redis:
+        condition: service_healthy
+    environment:
+      RAILS_ENV: production
+      RAILS_SERVE_STATIC_FILES: true # won't serve assets without this
+      RAILS_LOG_TO_STDOUT: true # logs to a file without this
+      SECRET_KEY_BASE: dev-secret # doesn't work without it
+      DISABLE_SECURE_COOKIES: true
+
+      CCQ_MODE: embedded
+      CCQ_EMBEDDED_LAYOUT: rcw/application
+      REDIS_URL: redis://redis:6379
+      HOST_SERVICE_URL: ${CCQ_HOST_SERVICE_URL:-http://rcw:3000}
+      HOST_SERVICE_LOAD_ENDPOINT: /api/private/load
+      HOST_SERVICE_SAVE_ENDPOINT: /api/private/save
+
+  redis:
+    container_name: ccq-embedded-redis
+    image: "redis:7.2-alpine"
+    command: >
+      redis-server --maxmemory 256mb  --maxmemory-policy allkeys-lru --save ""
+      --appendonly no
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,17 @@
+# Docker Compose automatically merges this on top of docker-compose.yml
+#
+# Separated from services included via `include:` in docker-compose.yml,
+# since a service can't be both included and overridden in the same file.
+services:
+  # Point at the stub instead of docker-compose.embedded.yml's default of a real host service.
+  ccq-embedded:
+    environment:
+      HOST_SERVICE_URL: http://host-service-stub:8080
+    depends_on:
+      host-service-stub:
+        condition: service_started
+
+  # Republish redis on the host port for local debugging.
+  redis:
+    ports:
+      - 6379:6379

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -1,0 +1,55 @@
+# Reusable building block: CCQ running in standalone mode, plus its own Postgres.
+services:
+  ccq-standalone:
+    container_name: ccq-standalone
+    image: laa-check-client-qualifies:latest
+    platform: linux/amd64
+    pull_policy: never # `make build`
+    environment:
+      RAILS_ENV: production
+      RAILS_SERVE_STATIC_FILES: true
+      RAILS_LOG_TO_STDOUT: true
+      SECRET_KEY_BASE: dev-secret
+
+      DISABLE_SECURE_COOKIES: true
+      PDF_DISPLAY_URL: http://localhost:3000
+
+      POSTGRES_HOST: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DATABASE: ccq
+    ports:
+      - "3001:3000"
+    depends_on:
+      migrator:
+        condition: service_completed_successfully
+
+  migrator:
+    container_name: ccq-standalone-postgres-migrator
+    image: laa-check-client-qualifies:latest
+    platform: linux/amd64
+    pull_policy: never # `make build`
+    command: bundle exec rails db:prepare
+    environment:
+      RAILS_ENV: production
+      SECRET_KEY_BASE: dev-secret
+      POSTGRES_HOST: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DATABASE: ccq
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  postgres:
+    container_name: ccq-standalone-postgres
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: ccq
+      POSTGRES_HOST_AUTH_METHOD: trust
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 2s
+      retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,12 @@
+include:
+  - docker-compose.embedded.yml
+  - docker-compose.standalone.yml
+
 services:
-  ############# embedded mode #############
+  # embedded dependencies
+  #
+  # separated so that other services can include
+  # docker-compose.embedded.yml without nginx/host stub
   nginx:
     container_name: ccq-embedded-nginx
     image: nginxinc/nginx-unprivileged:alpine
@@ -16,32 +23,6 @@ services:
       NGINX_UPSTREAM_CCQ: ccq_upstream
       NGINX_UPSTREAM_CCQ_SERVER: ccq-embedded:3000
 
-  ccq-embedded:
-    container_name: ccq-embedded
-    image: laa-check-client-qualifies:latest
-    platform: linux/amd64
-    pull_policy: never # `make build`
-    expose:
-      - 3000
-    depends_on:
-      redis:
-        condition: service_healthy
-      host-service-stub:
-        condition: service_started
-    environment:
-      RAILS_ENV: production
-      RAILS_SERVE_STATIC_FILES: true # won't serve assets without this
-      RAILS_LOG_TO_STDOUT: true # logs to a file without this
-      SECRET_KEY_BASE: dev-secret # doesn't work without it
-      DISABLE_SECURE_COOKIES: true
-
-      CCQ_MODE: embedded
-      CCQ_EMBEDDED_LAYOUT: rcw/application
-      REDIS_URL: redis://redis:6379
-      HOST_SERVICE_URL: http://host-service-stub:8080
-      HOST_SERVICE_LOAD_ENDPOINT: /api/private/load
-      HOST_SERVICE_SAVE_ENDPOINT: /api/private/save
-
   host-service-stub:
     container_name: ccq-host-service-stub
     image: wiremock/wiremock:3.13.1
@@ -49,72 +30,3 @@ services:
       - ./docker/compose/host-service-stub/mappings:/home/wiremock/mappings:ro
     command:
       - --global-response-templating
-
-  redis:
-    container_name: ccq-embedded-redis
-    image: "redis:7.2-alpine"
-    ports:
-      - 6379:6379
-    command: >
-      redis-server --maxmemory 256mb  --maxmemory-policy allkeys-lru --save ""
-      --appendonly no
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
-      timeout: 3s
-      retries: 5
-
-  ############# standalone mode #############
-  ccq-standalone:
-    container_name: ccq-standalone
-    image: laa-check-client-qualifies:latest
-    platform: linux/amd64
-    pull_policy: never # `make build`
-    environment:
-      RAILS_ENV: production
-      RAILS_SERVE_STATIC_FILES: true
-      RAILS_LOG_TO_STDOUT: true
-      SECRET_KEY_BASE: dev-secret
-
-      DISABLE_SECURE_COOKIES: true
-      PDF_DISPLAY_URL: http://localhost:3000
-
-      POSTGRES_HOST: postgres
-      POSTGRES_USER: postgres
-      POSTGRES_DATABASE: ccq
-    ports:
-      - "3001:3000"
-    depends_on:
-      migrator:
-        condition: service_completed_successfully
-
-  migrator:
-    container_name: ccq-standalone-postgres-migrator
-    image: laa-check-client-qualifies:latest
-    platform: linux/amd64
-    pull_policy: never # `make build`
-    command: bundle exec rails db:prepare
-    environment:
-      RAILS_ENV: production
-      SECRET_KEY_BASE: dev-secret
-      POSTGRES_HOST: postgres
-      POSTGRES_USER: postgres
-      POSTGRES_DATABASE: ccq
-    depends_on:
-      postgres:
-        condition: service_healthy
-
-  postgres:
-    container_name: ccq-standalone-postgres
-    image: postgres:15-alpine
-    environment:
-      POSTGRES_USER: postgres
-      POSTGRES_DB: ccq
-      POSTGRES_HOST_AUTH_METHOD: trust
-    ports:
-      - "5432:5432"
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
-      interval: 2s
-      timeout: 2s
-      retries: 5


### PR DESCRIPTION
Refactors docker-compose into a set of composable includes. This allows upstream services to include the authoritative version of the docker-compose config in their own docker-compose, rather than redefining it.